### PR TITLE
Permission Error on installing requirements

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -39,10 +39,10 @@ slate==0.3
 --index-url https://code.stripe.com --upgrade stripe
 
 # git repositories
-git+http://github.com/notanumber/xapian-haystack.git
+git+git://github.com/notanumber/xapian-haystack.git
 
 # timezones from master, fixes binding issue on sqlite
-git+http://github.com/brosner/django-timezones.git
+git+git://github.com/brosner/django-timezones.git
 
 # boto
 git+git://github.com/hmarr/boto@ses#egg=boto


### PR DESCRIPTION
... protocol or you get permission errors

``` bash
Downloading/unpacking git+http://github.com/notanumber/xapian-haystack.git (from -r scripts/requirements.txt (line 42))
  Cloning http://github.com/notanumber/xapian-haystack.git to /var/folders/tc/fxrnq0nx3nbcq7vr6w260r0c0000gn/T/pip-mjd_QW-build
error: The requested URL returned error: 403 while accessing http://github.com/notanumber/xapian-haystack.git/info/refs

fatal: HTTP request failed
  Complete output from command /usr/bin/git clone -q http://github.com/notanumber/xapian-haystack.git /var/folders/tc/fxrnq0nx3nbcq7vr6w260r0c0000gn/T/pip-mjd_QW-build:
```

You can see the 403 error. Switch to the git protocol solves the issue.
