### PR TITLE
Added Site Display above address

### DIFF
--- a/templates/invoices/view.html
+++ b/templates/invoices/view.html
@@ -18,6 +18,9 @@
 
 <h1>{% if obj_name %}{{ obj_name|capfirst }}{% endif %} Invoice</h1>
 
+{% if SITE_GLOBAL_SITEDISPLAYNAME %}
+<div class="invoice-site-name">{{ SITE_GLOBAL_SITEDISPLAYNAME }}</div>
+{% endif %}
 {% if SITE_GLOBAL_SITEMAILINGADDRESS %}
 <address class="invoice-site-address">{{ SITE_GLOBAL_SITEMAILINGADDRESS }}</address>
 {% endif %}


### PR DESCRIPTION
I added the Site Display Name above the address on the invoice to help identify the organization the invoice is from if it is printed.
