### PR TITLE
Rework dependencies and pip install

### DIFF
--- a/docs/source/installation/installation.txt
+++ b/docs/source/installation/installation.txt
@@ -46,8 +46,18 @@ the latest packages. For Ubuntu this is done by
     sudo apt-get dist-upgrade
 
 
-Pre-config
-----------
+Required Dependencies
+---------------------
+To go with the pip modules you're about to install you will need to ensure some
+other packages are installed:
+::
+
+    sudo apt-get install libpq-dev python-dev 
+
+You'll also need to have Git set up (see `this Github help article <https://help.github.com/articles/set-up-git>`_ for instructions).
+::
+
+    sudo apt-get install git
 
 For development install required packages
 ::
@@ -58,20 +68,28 @@ For development install required packages
 
 Note: Say 'Yes' when it asks about security updates. Without security we have nothing.
 
-Install distribute if not already installed. Required to install easy_install.
+Pip Install
+----------
+Depending on your version of python `pip <http://www.pip-installer.org/>`_ is
+installed differently. If your system is python 2.7.9 or later pip can be
+installed with:
 ::
 
-    sudo wget http://python-distribute.org/distribute_setup.py
-    python distribute_setup.py
+    apt-get install python-pip
 
-    sudo apt-get install python-setuptools python-dev build-essential
 
-Install `pip <http://www.pip-installer.org/>`_:
+If your system is pre Python 2.7.9 you will need to install pip from the Internet.
+The following command will download and install pip and its dependencies for you.
 ::
 
-    sudo easy_install pip
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python
 
-Install `virtualenv <http://www.virtualenv.org/>`_:
+
+Virtualenv install
+------------------
+
+Once pip is installed you can continue to install
+`virtualenv <http://www.virtualenv.org/>`_:
 ::
 
     pip install virtualenv
@@ -81,10 +99,9 @@ If you are using OS X, you may need to sudo that command with:
 
     sudo pip install virtualenv
 
-You'll also need to have Git set up (see `this Github help article <https://help.github.com/articles/set-up-git>`_ for instructions).
 
-OS X Pre-config
-~~~~~~~~~~~~~~~
+OS X specific
+-------------
 
 In order for images to correctly render, you will need to install the jpeg libraries with the commands below:
 ::
@@ -151,11 +168,6 @@ Create the database and a new postgres user with the following commands (replace
     sudo -u postgres psql postgres -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER;"
     sudo -u postgres psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;"
     sudo -u postgres psql postgres -d $DB_NAME -c "CREATE EXTENSION postgis;"
-    psql -d <DB_NAME> -c "CREATE EXTENSION postgis;"
-    psql -d <DB_NAME> -c "CREATE EXTENSION postgis_topology;"
-    psql -d <DB_NAME> -c "CREATE EXTENSION fuzzystrmatch;"
-    psql -d <DB_NAME> -c "CREATE EXTENSION postgis_tiger_geocoder;"
-
 
 
 Creating a new tendenci project


### PR DESCRIPTION
The motivation for this was to remove the overly complex (and incorrect) easy
install instructions and replace them with the modern way of doing pip
installs.

While at it I decided some of the segmentation didn't make sense (like calling
it 'pre config') so I renamed and rearranged a couple of related sections.