### PR TITLE
Minor update docs (for master)

### DIFF
--- a/docs/source/upgrade/point-update.txt
+++ b/docs/source/upgrade/point-update.txt
@@ -1,0 +1,21 @@
+Performing a minor update
+=========================
+
+When a minor update comes out the following steps will upgrade tendenci and its dependencies
+::
+    pip install tendenci --upgrade
+    python deploy.py
+
+If dependencies need to be upgraded at the same tiem run pip against the requirements file.
+::
+    pip install -r requirements.txt --upgrade
+    python deploy.py
+
+To ensure no stale data is carried over in caches between versions clear the application cache and restart.
+::
+    python manage.py clear_cache
+    service tendenci restart
+
+
+These steps come from Issue #341 and Issue #373 and more or less match those in update_tendenci.py
+

--- a/docs/source/upgrade/point-update.txt
+++ b/docs/source/upgrade/point-update.txt
@@ -6,7 +6,7 @@ When a minor update comes out the following steps will upgrade tendenci and its 
     pip install tendenci --upgrade
     python deploy.py
 
-If dependencies need to be upgraded at the same tiem run pip against the requirements file.
+If dependencies need to be upgraded at the same time run pip against the requirements file.
 ::
     pip install -r requirements.txt --upgrade
     python deploy.py
@@ -15,7 +15,3 @@ To ensure no stale data is carried over in caches between versions clear the app
 ::
     python manage.py clear_cache
     service tendenci restart
-
-
-These steps come from Issue #341 and Issue #373 and more or less match those in update_tendenci.py
-


### PR DESCRIPTION
This follows on from #438 , adding commands to be run for minor updates.

Still to be decided are the following:
* Best way to handle minor version updates
 - pip install -r requirements/tendenci.txt --upgrade.
 - a versioned upgrade using pip?
* Should it be updated to talk about tendenci 7.1 right away
