### PR TITLE
Run tendenci as www-data

### DIFF
--- a/docs/source/installation/installation.txt
+++ b/docs/source/installation/installation.txt
@@ -267,6 +267,7 @@ Finally, we can use the runserver command so that we can view the site in our br
 
 Open http://127.0.0.1:8000/ in your browser to see your tendenci site!
 
+
 Theming Options
 ----------------
 

--- a/docs/source/installation/installation.txt
+++ b/docs/source/installation/installation.txt
@@ -267,7 +267,6 @@ Finally, we can use the runserver command so that we can view the site in our br
 
 Open http://127.0.0.1:8000/ in your browser to see your tendenci site!
 
-
 Theming Options
 ----------------
 
@@ -296,6 +295,15 @@ You can install all of the necessary Ubuntu packages with the following commands
 This will install openssh-server to allow remote connections to the server
 along with memcache (a caching system) and nginx the web server.
 
+Permissions
+-----------
+To change Tendenci to run as www-data (dropping root priviledges and increasing security) change permissions on the data directory (the Upstart and Systemd configuration provided below already runs tendenci as www-data)
+
+::
+
+    sudo chown -R www-data: /var/www/<project_name>
+
+
 Setting up Upstart
 ------------------
 
@@ -315,6 +323,8 @@ The contents of that file should match the example below:
     stop on runlevel [06]
     respawn
     respawn limit 10 5
+    setuid www-data
+    setgid www-data
     script
         cd /var/www/<project_name>
         exec gunicorn -w 2 -b 127.0.0.1:8000 conf.wsgi --max-requests 350


### PR DESCRIPTION
This fixes #461 by running tendenci as www-data. I've done a quick test on an ubuntu system and it works so far (running as www-data via systemd appears to be fine too).