### PR TITLE
Change tax calculation

### DIFF
--- a/tendenci/apps/memberships/models.py
+++ b/tendenci/apps/memberships/models.py
@@ -378,7 +378,7 @@ class MembershipSet(models.Model):
         tax = 0
         if app and app.include_tax:
             invoice.tax_rate = app.tax_rate
-            tax = app.tax_rate * price
+            tax = app.tax_rate * price / 100
             invoice.tax = tax
 
         invoice.subtotal = price + tax
@@ -2286,8 +2286,7 @@ class MembershipApp(TendenciBaseModel):
     membership_types = models.ManyToManyField(MembershipType,
                                               verbose_name="Membership Types")
     include_tax = models.BooleanField(default=False)
-    tax_rate = models.DecimalField(blank=True, max_digits=5, decimal_places=4, default=0,
-                                   help_text=_('Example: 0.0825 for 8.25%.'))
+    tax_rate = models.DecimalField(blank=True, max_digits=5, decimal_places=2, default=0)
     payment_methods = models.ManyToManyField(PaymentMethod,
                                              verbose_name=_("Payment Methods"))
     discount_eligible = models.BooleanField(default=False)


### PR DESCRIPTION
Hi,
Rather than forcing the user to put in some weird not-quite-percentage number I
suggest putting the division by 100 in code rather than in the users head.

I'm not sure if this will require changes to existing systems or custom migrations - I'm hoping you can clarify that for me.