### PR TITLE
Fix photo download filenames

### DIFF
--- a/tendenci/apps/photos/utils/caching.py
+++ b/tendenci/apps/photos/utils/caching.py
@@ -47,11 +47,11 @@ def cache_photo_size(id, size, crop=False, quality=90, download=False, constrain
         return request_path
 
     response = HttpResponse(content_type='image/jpeg')
-    response['Content-Disposition'] = ' filename=%s' % photo.image.file.name
+    response['Content-Disposition'] = ' filename=%s' % photo.image_filename()
     image.save(response, "JPEG", quality=quality)
 
     if photo.is_public_photo() and photo.is_public_photoset():
-        file_name = photo.image.file.name
+        file_name = photo.image_filename()
         file_path = 'cached%s%s' % (request_path, file_name)
         default_storage.save(file_path, ContentFile(response.content))
         full_file_path = "%s%s" % (settings.MEDIA_URL, file_path)

--- a/tendenci/apps/photos/views.py
+++ b/tendenci/apps/photos/views.py
@@ -226,7 +226,7 @@ def photo_size(request, id, size, crop=False, quality=90, download=False, constr
         raise Http404
 
     response = HttpResponse(content_type='image/jpeg')
-    response['Content-Disposition'] = '%s filename=%s' % (attachment, photo.image.file.name)
+    response['Content-Disposition'] = '%s filename=%s' % (attachment, photo.image_filename())
     image.save(response, "JPEG", quality=quality)
 
     if photo.is_public_photo() and photo.is_public_photoset():


### PR DESCRIPTION
When downloading photos (http://example.com/photos/download/1/640x480/),
the filename in the Content-Disposition header included the full path to
the file on the server, but with slashes replaced with dashes.  This was
both an annoyance (as the user is not likely to want the path included
in the filename), and potentially a security issue (as it may provide an
attacker with useful information about the Tendenci installation on the
server).

This commit ensures that the path is removed from the filename before
adding it to the Content-Disposition header.