### PR TITLE
Fix search indexes

### DIFF
--- a/tendenci/apps/events/utils.py
+++ b/tendenci/apps/events/utils.py
@@ -10,6 +10,7 @@ from dateutil.rrule import *
 from decimal import Decimal
 
 from django.contrib.auth.models import User
+from django.core.exceptions import AppRegistryNotReady
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.db import connection
@@ -27,8 +28,18 @@ from tendenci.apps.events.models import (Event, Place, Speaker, Organizer,
     Registration, RegistrationConfiguration, Registrant, RegConfPricing,
     CustomRegForm, Addon, AddonOption, CustomRegField, Type,
     TypeColorSet, RecurringEvent)
-from tendenci.apps.events.forms import (FormForCustomRegForm,
+try: from tendenci.apps.events.forms import (FormForCustomRegForm,
     EMAIL_AVAILABLE_TOKENS)
+# This module is imported by search_indexes.py during Django initialization
+# before translations are available.  However, tendenci.apps.events.forms
+# imports tendenci.apps.base.forms, which iterates through
+# django_countries.countries, which causes the django_countries module to
+# attempt to translate the country names.  search_indexes.py does not require
+# any of the functionality provided by tendenci.apps.events.forms, so simply
+# ignore the exception that is thrown when this happens.
+# tendenci.apps.events.forms will be imported again later when this module is
+# imported by other modules after Django initialization.
+except AppRegistryNotReady: pass
 from tendenci.apps.discounts.models import Discount, DiscountUse
 from tendenci.apps.discounts.utils import assign_discount
 from tendenci.apps.site_settings.utils import get_setting

--- a/tendenci/apps/forms_builder/forms/models.py
+++ b/tendenci/apps/forms_builder/forms/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import AppRegistryNotReady
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext, ugettext_lazy as _
@@ -7,7 +8,13 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.shortcuts import get_object_or_404
 
 from django_countries import countries as COUNTRIES
-from localflavor.us.us_states import STATE_CHOICES
+try: from localflavor.us.us_states import STATE_CHOICES
+# Work-around for https://github.com/django/django-localflavor/issues/203
+# If using django-localflavor 1.2 or 1.3, ignore the exception thrown when
+# importing STATE_CHOICES during Django initialization (when this module is
+# imported via search_indexes.py).  STATE_CHOICES will be imported again later
+# when this module is imported by other modules after Django initialization.
+except AppRegistryNotReady: pass
 from localflavor.ca.ca_provinces import PROVINCE_CHOICES
 
 from tendenci.apps.forms_builder.forms.settings import FIELD_MAX_LENGTH, LABEL_MAX_LENGTH

--- a/tendenci/apps/search/signals.py
+++ b/tendenci/apps/search/signals.py
@@ -27,7 +27,7 @@ class QueuedSignalProcessor(signals.BaseSignalProcessor):
         for app in settings.INSTALLED_APPS:
             try:
                 __import__(app + '.search_indexes')
-            except:
+            except ImportError:
                 pass
         return [c.get_model() for c in TendenciBaseSearchIndex.__subclasses__()]    
        

--- a/tendenci/libs/tinymce/settings.py
+++ b/tendenci/libs/tinymce/settings.py
@@ -14,7 +14,6 @@ USE_FILEBROWSER = getattr(settings, 'TINYMCE_FILEBROWSER',
 
 if 'staticfiles' in settings.INSTALLED_APPS or 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
     JS_URL = getattr(settings, 'TINYMCE_JS_URL',os.path.join(settings.STATIC_URL, 'tiny_mce/tiny_mce.js'))
-    JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', finders.find('tiny_mce', all=False))
 else:
     JS_URL = getattr(settings, 'TINYMCE_JS_URL','%sjs/tiny_mce/tiny_mce.js' % settings.MEDIA_URL)
     JS_ROOT = getattr(settings, 'TINYMCE_JS_ROOT', os.path.join(settings.MEDIA_ROOT, 'js/tiny_mce'))


### PR DESCRIPTION
It looks like the updating of most search indexes has been broken since 7.2.0 was released.  You can still search old entries that were added to the search indexes before upgrading to 7.2.0, but any new content that is added to a Tendenci site after upgrading to 7.2.0 will not show up in the search results.  Indexing of events and forms_builder items may have been broken since before 7.2.0 (I'm not sure exactly when those broke).

These commits fix the indexes so they are now updated as new content is added.

However, it doesn't look like there is any way to re-index existing content.  (tendenci/apps/search/management/commands/process_unindexed.py will index queued items, but these search index problems prevented new items from even being added to the search index queue, so that doesn't help.)  Someone might want to write a script to re-index all existing content to clean this up on existing sites.