### PR TITLE
Fix handling of hidden folders in theme_editor

### DIFF
--- a/tendenci/apps/theme_editor/utils.py
+++ b/tendenci/apps/theme_editor/utils.py
@@ -181,28 +181,26 @@ def get_all_files_list(ROOT_DIR=THEME_ROOT):
 
     start = root_dir.rfind(os.sep) + 1
     for path, dirs, files in os.walk(root_dir):
-        subdir = {'contents': []}
         folders = path[start:].split(os.sep)
+
+        # Hide hidden folders and folders within hidden folders
+        if any(folder.startswith('.') for folder in folders):
+            continue
+
+        subdir = {'contents': []}
         for f in files:
             editable = False
             if os.path.splitext(os.path.join(path, f))[1] in ALLOWED_EXTENSIONS:
                 editable = True
 
-            # Hide hidden folders
+            # Hide hidden files
             if not f.startswith('.'):
                 subdir['contents'].append({'name': f, 'path': os.path.join(path[len(root_dir) + 1:], f), 'editable': editable})
 
         subdir['contents'] = sorted(subdir['contents'], key=itemgetter('name'))
+        subdir['contents'].append({'folder_path': path})
         parent = reduce(dict.get, folders[:-1], files_folders)
-
-        # Hide hidden folders
-        if not folders[-1].startswith('.'):
-            parent[folders[-1]] = subdir
-
-        for parent in files_folders:
-            # Hide hidden folders
-            if not path.split(os.sep)[-1].startswith('.'):
-                subdir['contents'].append({'folder_path': path})
+        parent[folders[-1]] = subdir
 
     if settings.USE_S3_THEME:
         s3_files_folders = {'contents': []}


### PR DESCRIPTION
The previous code would throw an exception if a non-hidden folder was
nested inside a hidden folder.  This is because os.walk() traverses into
hidden folders, and the code searches for the parent of each non-hidden
folder in files_folders, but it doesn't add hidden folders to
files_folders, and it doesn't handle the case where the parent is
not found in files_folders.  So a non-hidden folder in a hidden folder
causes the parent search to fail.