### PR TITLE
Fix view permissions on objects with 1 digit primary keys

### DIFF
--- a/tendenci/apps/perms/backend.py
+++ b/tendenci/apps/perms/backend.py
@@ -169,6 +169,8 @@ class ObjectPermBackend(object):
                 index = site.get_index(obj.__class__)
                 if can_view(user, obj):
                     return True
+            except AssertionError:
+                raise
             except:
                 pass
 

--- a/tendenci/apps/perms/indexes.py
+++ b/tendenci/apps/perms/indexes.py
@@ -30,11 +30,9 @@ class TendenciBaseSearchIndex(indexes.SearchIndex):
     update_dt = indexes.DateTimeField(model_attr='update_dt', null=True)
 
     # permission fields
+    primary_key = indexes.IntegerField(model_attr='pk')
     users_can_view = indexes.MultiValueField(null=True)
     groups_can_view = indexes.MultiValueField(null=True)
-
-    # PK: needed for exclude list_tags
-    primary_key = indexes.CharField(model_attr='pk')
 
     # add order field for sorting. the subclasses can override
     # the prepare_order method to sort by a different field

--- a/tendenci/apps/perms/utils.py
+++ b/tendenci/apps/perms/utils.py
@@ -348,6 +348,10 @@ def _specific_view(user, obj):
         sqs = sqs.filter(q_primary_key & q_users)
 
     if sqs:
+        # Make sure the index isn't doing something unexpected with the query,
+        # like when the Whoosh StopFilter caused the primary_key portion of the
+        # query to be ignored.
+        assert len(sqs) == 1, "Index returned an unexpected result set when searching for view permissions on an object"
         return True
 
     return False


### PR DESCRIPTION
If search indexes are available, has_perm() in apps/perms/backend.py
calls can_view() in apps/perms/utils.py to determine whether a user has
view permissions on an object.  can_view() queries the index for
documents matching (SQ(primary_key=obj.pk) & (q_groups | q_users)) and
returns True if any matching documents are found.

Since the primary_key index field is defined as a CharField, Whoosh
applies StopFilter to the query for that field.  If the query value is
less than 2 characters long (if the object's primary key happens to be
<= 9) then StopFilter removes that query from the query set, reducing
the query to just (q_groups | q_users).

That causes documents to be returned (and can_view() to return True) if
the user has view permissions on any objects in the index.

This commit fixes the issue by changing primary_key to an IntegerField
such that StopFilter will not be applied to queries on that field.

In addition, a sanity check is added to can_view() to help ensure that
the result set returned by the index makes sense.