### PR TITLE
Add NoticeType "membership_notice_email", remove bare except.

### DIFF
--- a/tendenci/apps/memberships/signals.py
+++ b/tendenci/apps/memberships/signals.py
@@ -17,7 +17,7 @@ def update_membs_app_id(sender, **kwargs):
     app_to_be_deleted = kwargs['instance']
     switch_memberships_app_id(app_to_be_deleted)
 
-       
+
 def switch_memberships_app_id(app_from):
     # each membership has an app_id associated.
     # since this app is to be deleted, we need to update memberships
@@ -31,7 +31,7 @@ def switch_memberships_app_id(app_from):
     if app:
         MembershipDefault.objects.filter(app_id=app_from.id).update(app=app)
 
-        
+
 def create_notice_types(app, created_models, verbosity, **kwargs):
     notification.create_notice_type(
         "user_welcome",
@@ -79,10 +79,15 @@ def create_notice_types(app, created_models, verbosity, **kwargs):
         _('Membership Application Disapproved'))
 
     notification.create_notice_type(
+        'membership_notice_email',
+        _('Membership Expiry'),
+        _('Membership Expiry'))
+
+    notification.create_notice_type(
         'membership_corp_indiv_verify_email',
         _('Membership Corp Indiv Verify Email'),
         _('Membership Corp Indiv Email To Be Verified'))
-    
+
 
 # assign models permissions to the admin auth group
 def assign_permissions(app, created_models, verbosity, **kwargs):
@@ -94,4 +99,3 @@ post_delete.connect(update_membs_app_id, sender=MembershipApp, weak=False)
 post_save.connect(check_and_update_membs_app_id, sender=MembershipApp, weak=False)
 post_syncdb.connect(create_notice_types, sender=notification)
 post_syncdb.connect(assign_permissions, sender=__file__)
-

--- a/tendenci/apps/notifications/models.py
+++ b/tendenci/apps/notifications/models.py
@@ -1,5 +1,6 @@
 from os.path import splitext
 import datetime
+import logging
 import uuid
 
 try:
@@ -25,10 +26,12 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext, get_language, activate
 from django.utils.safestring import mark_safe
-from django.utils.html import escape
 
 from tendenci.apps.site_settings.utils import get_setting
 from tendenci.apps.emails.models import Email
+
+
+logger = logging.getLogger(__name__)
 
 QUEUE_ALL = getattr(settings, "NOTIFICATION_QUEUE_ALL", False)
 
@@ -338,7 +341,9 @@ def send_emails(emails, label, extra_context=None, on_site=True):
 
     try:
         notice_type = NoticeType.objects.get(label=label)
-    except:
+    except NoticeType.DoesNotExist as err:
+        logger.warning('Skipping notification send for "{label}": {err}'.format(
+            label=label, err=err))
         # Stop here because we need a notice_type
         return None
 


### PR DESCRIPTION
…eTypes.

The "membership_notice_email" NoticeType is referenced in
`apps.memberships.management.commands.send_membership_notices`, but not created
during migrations.

Additionally remove bare except and add some logging. Bare excepts are generally
a bad idea because they hide the cause of problems.

Fixes #576.