### PR TITLE
Disable the correct button during event registration

### DIFF
--- a/tendenci/apps/events/templates/events/reg8n/register.html
+++ b/tendenci/apps/events/templates/events/reg8n/register.html
@@ -359,7 +359,7 @@
                     <div class="field">{{ reg_form.captcha }}</div>
                 </div>
             {% endif %}
-            <input type="submit" name="commit" id="register-button" class="registration-green-button" value="{% if event.free_event %}{% trans 'RSVP' %}{% else %}{% trans 'Register'%}{% endif %}" />
+            <input type="submit" name="commit" id="register-form-button" class="registration-green-button" value="{% if event.free_event %}{% trans 'RSVP' %}{% else %}{% trans 'Register'%}{% endif %}" />
 
             <div class="clear"></div>
         </div>


### PR DESCRIPTION
register.html and multi-register.html include javascript to disable
"register-button" after it has been clicked to prevent duplicate
registrations.

Commit 0068f28c26 updated register.html to add a confirmation page which
is displayed after the registration form is submitted and before it is
committed to the database.  This confirmation page renders a hidden
copy of the original form (including the original "register-button")
plus an additional "register-button" to confirm the registration.

That commit caused two problems:
1) The "register-button" on the registration form is disabled when
the user moves to the confirmation page, and most browsers maintain that
disabled state if the user clicks the back button on the confirmation
page, which prevents the user from correcting any errors in their
registration before confirming it.  (After hitting the back button, the
user is forced to either hit refresh on the registration form and start
over, or hit the forward button to go back to the confirmation page
without making any changes to their registration.)
2) The javascript to disable "register-button" on the confirmation page
disables the first register-button on the page (which is in the hidden
copy of the original form), and does not disable the second
register-button on that page (the button that is actually displayed to
the user).  Because of this, users can click the "Confirm" button
multiple times, which submits duplicate registrations.

This commit fixes the problem by renaming the button on the registration
form (but not on the confirmation page), which both prevents the button on
the form from being disabled and allows the button on the confirmation
page to be properly disabled.