### PR TITLE
Fixed ordering attribute for videos in creative defaults fixture

### DIFF
--- a/tendenci/apps/videos/fixtures/creative_default_videos.json
+++ b/tendenci/apps/videos/fixtures/creative_default_videos.json
@@ -17,7 +17,7 @@
         "category": 1,
         "create_dt": "2015-09-21T14:46:47.268",
         "update_dt": "2015-09-21T16:18:27.548",
-        "ordering": 0,
+        "position": 0,
         "image": "",
         "owner_username": "system_generated",
         "allow_anonymous_view": true,


### PR DESCRIPTION
Hello @jennyq,

Currently when I try to [load the creative defaults](https://tendenci.readthedocs.io/en/latest/installation/installation.html#setting-up-the-site), I get this error on the videos app:

```bash
(venv) replaceafill@eluk:/opt/tendenci/theming/instance$ python manage.py load_creative_defaults
creative_default_auth_user.json
Installed 1 object(s) from 1 fixture(s)
creative_default_auth_groups.json
Installed 18 object(s) from 1 fixture(s)
creative_default_entities.json
Installed 67 object(s) from 1 fixture(s)
creative_default_user_groups.json
Installed 19 object(s) from 1 fixture(s)
creative_default_files.json
Installed 51 object(s) from 1 fixture(s)
load creative_default_paymentmethod.json
Installed 3 object(s) from 1 fixture(s)
load creative_default_forums.json
Installed 25 object(s) from 1 fixture(s)
load creative_default_regions_region.json
Installed 7 object(s) from 1 fixture(s)
load creative_default_directories_pricings.json
Installed 2 object(s) from 1 fixture(s)
creative_default_profiles_profile.json
Installed 1 object(s) from 1 fixture(s)
creative_default_explorer.json
Installed 5 object(s) from 1 fixture(s)
creative_default_events.json
Installed 74 object(s) from 1 fixture(s)
creative_default_jobs.json
Installed 4 object(s) from 1 fixture(s)
creative_default_memberships.json
Installed 287 object(s) from 1 fixture(s)
creative_default_corporate_memberships.json
Installed 66 object(s) from 1 fixture(s)
creative_default_articles.json
Installed 1 object(s) from 1 fixture(s)
creative_default_forms.json
Installed 67 object(s) from 1 fixture(s)
creative_default_forums.json
Installed 25 object(s) from 1 fixture(s)
creative_default_news.json
Installed 2 object(s) from 1 fixture(s)
creative_default_photos.json
Installed 22 object(s) from 1 fixture(s)
creative_default_boxes.json
Installed 20 object(s) from 1 fixture(s)
creative_default_pages.json
Installed 16 object(s) from 1 fixture(s)
creative_default_navs.json
Installed 43 object(s) from 1 fixture(s)
creative_default_stories.json
Installed 13 object(s) from 1 fixture(s)
creative_default_videos.json
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/opt/tendenci/tendenci/tendenci/apps/base/management/commands/load_creative_defaults.py", line 29, in handle
    self.call_loaddata(reset_nav)
  File "/opt/tendenci/tendenci/tendenci/apps/base/management/commands/load_creative_defaults.py", line 99, in call_loaddata
    call_command('loaddata', filename)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 120, in call_command
    return command.execute(*args, **defaults)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 60, in handle
    self.loaddata(fixture_labels)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 100, in loaddata
    self.load_label(fixture_label)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/management/commands/loaddata.py", line 151, in load_label
    for obj in objects:
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/serializers/json.py", line 85, in Deserializer
    six.reraise(DeserializationError, DeserializationError(e), sys.exc_info()[2])
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/serializers/json.py", line 79, in Deserializer
    for obj in PythonDeserializer(objects, **options):
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/core/serializers/python.py", line 120, in Deserializer
    field = Model._meta.get_field(field_name)
  File "/opt/tendenci/theming/venv/local/lib/python2.7/site-packages/django/db/models/options.py", line 554, in get_field
    raise FieldDoesNotExist('%s has no field named %r' % (self.object_name, field_name))
django.core.serializers.base.DeserializationError: Problem installing fixture '/opt/tendenci/tendenci/tendenci/apps/videos/fixtures/creative_default_videos.json': Video has no field named u'ordering'
```

If I understand correcly this was caused by the use of [the new OrderingBaseModel abstract](https://github.com/tendenci/tendenci/blob/master/tendenci/libs/abstracts/models.py#L177-L183) on the Video model, which removes the old ordering field in favor of the position field.