### PR TITLE
Defer executing DB queries

### DIFF
--- a/tendenci/apps/memberships/reports.py
+++ b/tendenci/apps/memberships/reports.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext as _
 from tendenci.libs.model_report.report import reports, ReportAdmin
 from tendenci.libs.model_report.utils import count_column, us_date_format, yesno_format
 from tendenci.apps.memberships.models import MembershipDefault, MembershipType
+MEMBERSHIPTYPE_DICT = None
 
 class ReportBandNewMems(ReportBand):
     def __init__(self, *args, **kwargs):
@@ -60,8 +61,10 @@ def id_format(value, instance):
 
 
 def membership_type_format(value, instance=None):
-    membership_types = dict((m.id, m.name) for m in MembershipType.objects.all())
-    return membership_types.get(value, value)
+    global MEMBERSHIPTYPE_DICT
+    if not MEMBERSHIPTYPE_DICT:
+        MEMBERSHIPTYPE_DICT = dict((m.id, m.name) for m in MembershipType.objects.all())
+    return MEMBERSHIPTYPE_DICT.get(value, value)
 
 class MembershipReport(ReportAdmin):
     # choose a title for your report for h1, title tag and report list

--- a/tendenci/apps/memberships/reports.py
+++ b/tendenci/apps/memberships/reports.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext as _
 from tendenci.libs.model_report.report import reports, ReportAdmin
 from tendenci.libs.model_report.utils import count_column, us_date_format, yesno_format
 from tendenci.apps.memberships.models import MembershipDefault, MembershipType
-MEMBERSHIPTYPE_DICT = dict((m.id, m.name) for m in MembershipType.objects.all())
 
 class ReportBandNewMems(ReportBand):
     def __init__(self, *args, **kwargs):
@@ -61,8 +60,8 @@ def id_format(value, instance):
 
 
 def membership_type_format(value, instance=None):
-    return MEMBERSHIPTYPE_DICT.get(value, value)
-
+    membership_types = dict((m.id, m.name) for m in MembershipType.objects.all())
+    return membership_types.get(value, value)
 
 class MembershipReport(ReportAdmin):
     # choose a title for your report for h1, title tag and report list

--- a/tendenci/libs/model_report/utils.py
+++ b/tendenci/libs/model_report/utils.py
@@ -8,14 +8,10 @@ from django.contrib.contenttypes.models import ContentType
 from tendenci.apps.entities.models import Entity
 
 
-OBJECT_TYPE_DICT = dict((ct.id, '%s: %s' % (ct.app_label, ct.model))
-                        for ct in ContentType.objects.all().order_by('app_label', 'model'))
 DEFAULT_OBJ_TYPES = ('registration', 'membershipdefault',
                      'membershipset', 'makepayment',
                      'corpmembership', 'job',
                      'donation')
-ENTITY_DICT = dict((e.id, e.entity_name) for e in Entity.objects.all())
-
 def base_label(report, field):
     """
     Basic label
@@ -97,11 +93,14 @@ def date_label(report, field):
 
 
 def obj_type_format(value, instance=None):
-    return OBJECT_TYPE_DICT.get(value)
+    object_types = dict((ct.id, '%s: %s' % (ct.app_label, ct.model))
+                        for ct in ContentType.objects.all().order_by('app_label', 'model'))
+    return object_types.get(value)
 
 
 def entity_format(value):
-    return '%s (Entity ID: %s)' % (ENTITY_DICT.get(value), value)
+    entities = dict((e.id, e.entity_name) for e in Entity.objects.all())
+    return '%s (Entity ID: %s)' % (entities.get(value), value)
 
 
 def date_from_datetime(value):

--- a/tendenci/libs/model_report/utils.py
+++ b/tendenci/libs/model_report/utils.py
@@ -7,11 +7,13 @@ from django.utils.encoding import force_unicode
 from django.contrib.contenttypes.models import ContentType
 from tendenci.apps.entities.models import Entity
 
-
 DEFAULT_OBJ_TYPES = ('registration', 'membershipdefault',
                      'membershipset', 'makepayment',
                      'corpmembership', 'job',
                      'donation')
+OBJECT_TYPE_DICT = None
+ENTITY_DICT = None
+
 def base_label(report, field):
     """
     Basic label
@@ -93,14 +95,18 @@ def date_label(report, field):
 
 
 def obj_type_format(value, instance=None):
-    object_types = dict((ct.id, '%s: %s' % (ct.app_label, ct.model))
+    global OBJECT_TYPE_DICT
+    if not OBJECT_TYPE_DICT:
+        OBJECT_TYPE_DICT = dict((ct.id, '%s: %s' % (ct.app_label, ct.model))
                         for ct in ContentType.objects.all().order_by('app_label', 'model'))
-    return object_types.get(value)
+    return OBJECT_TYPE_DICT.get(value)
 
 
 def entity_format(value):
-    entities = dict((e.id, e.entity_name) for e in Entity.objects.all())
-    return '%s (Entity ID: %s)' % (entities.get(value), value)
+    global ENTITY_DICT
+    if not ENTITY_DICT:
+        ENTITY_DICT = dict((e.id, e.entity_name) for e in Entity.objects.all())
+    return '%s (Entity ID: %s)' % (ENTITY_DICT.get(value), value)
 
 
 def date_from_datetime(value):


### PR DESCRIPTION
When importing memberships.reports or model_report.utils the database queries
are run immediately.
This causes problems when run through pytest-django (and possibly other tools)
which suppress unrequested DB access as a matter of course

I've opted to defer the queries here as I saw the same method used elseware in
those files and thought it was likely to be an acceptable solution.

I enquired with pytest-django (#573) if they had some official documentation they could point me to but unfortunately no response has been forthcoming.