### PR TITLE
Amend URL to help file

### DIFF
--- a/tendenci/apps/site_settings/settings.json
+++ b/tendenci/apps/site_settings/settings.json
@@ -205,7 +205,7 @@
     },
     {
         "default_value": "AuthorizeNet",
-        "description": "If you have a merchant account, enter the name of your merchant account service provider. View the help file on <a href='https://www.tendenci.com/help-files/setup-online-payment-tendenci-t5-site/'>how to set up online payment</a>.",
+        "description": "If you have a merchant account, enter the name of your merchant account service provider. View the help file on <a href='https://www.tendenci.com/help-files/configure-online-payments-merchant-provider-tendenci/'>how to set up online payment</a>.",
         "data_type": "string",
         "update_dt": "2011-04-28 13:59:53",
         "input_type": "text",


### PR DESCRIPTION
While the T5 setup page redirects, its cleaner to point directly to the correct
page - pleasingly the same page linked to in #645.