### PR TITLE
Fix queryset filter for "disapprove" admin action.

### DIFF
--- a/tendenci/apps/memberships/admin.py
+++ b/tendenci/apps/memberships/admin.py
@@ -132,7 +132,7 @@ def disapprove_selected(modeladmin, request, queryset):
     qs_pending = Q(status_detail='pending')
     qs_active = Q(status_detail='active')
 
-    memberships = queryset.filter(qs_pending, qs_active)
+    memberships = queryset.filter(qs_pending | qs_active)
 
     for membership in memberships:
         is_renewal = membership.is_renewal()


### PR DESCRIPTION
The "approved" and "pending" filters were being and-ed where they should be or-ed, resulting in an always empty queryset, ie. the "disapprove" admin action didn't do anything.

For comparison, see `approve_selected()` on line 92.