### PR TITLE
notifications: Fix spacing in "From:" header causing spamminess.

### DIFF
--- a/tendenci/apps/emails/models.py
+++ b/tendenci/apps/emails/models.py
@@ -94,7 +94,7 @@ class Email(TendenciBaseModel):
         if self.sender_display:
             # Add quotes around display name to prevent errors on sending
             # When display name contains comma or other control characters,
-            headers['From'] = '"%s"<%s>' % (self.sender_display, self.sender)
+            headers['From'] = '"%s" <%s>' % (self.sender_display, self.sender)
         if self.priority and self.priority == 1:
             headers['X-Priority'] = '1'
             headers['X-MSMail-Priority'] = 'High'

--- a/tendenci/apps/notifications/models.py
+++ b/tendenci/apps/notifications/models.py
@@ -416,7 +416,7 @@ def send_emails(emails, label, extra_context=None, on_site=True):
     sender_display = extra_context.get('sender_display', '')
     # Add quotes around display name to prevent errors on sending
     # when display name contains comma or other control characters, - jennyq
-    from_display = '"%s"<%s>' % (sender_display, sender)
+    from_display = '"%s" <%s>' % (sender_display, sender)
 
     if sender_display:
         headers['From'] = from_display


### PR DESCRIPTION
In our testing, the mail header looks like this:

    From: "Fourth Estate Memberships"<no-reply@fourthestate.email>

Spam Assassin rates this bad spacing as "FROM_MISSP_EH_MATCH 1.441", a significant increase to the overall spam score.

Fixing the spacing reduced the spam score accordingly.