### PR TITLE
WIP: memberships: Allow multiple online payment methods in application form.

### DIFF
--- a/tendenci/apps/memberships/views.py
+++ b/tendenci/apps/memberships/views.py
@@ -1279,9 +1279,10 @@ def membership_default_add(request, slug='', membership_id=None,
 
             # redirect: payment gateway
             if membership_set.is_paid_online():
+                merchant_account = membership_form2.cleaned_data['payment_method'].machine_name
                 return HttpResponseRedirect(reverse(
                     'payment.pay_online',
-                    args=[invoice.pk, invoice.guid]
+                    args=[merchant_account, invoice.pk, invoice.guid]
                 ))
 
             # redirect: membership edit page

--- a/tendenci/apps/payments/urls.py
+++ b/tendenci/apps/payments/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url, include
 
 urlpatterns = patterns('tendenci.apps.payments.views',
-    url(r'^payonline/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', 'pay_online', name="payment.pay_online"),
+    url(r'^payonline/(?P<merchant_account>\w+)/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', 'pay_online', name="payment.pay_online"),
     (r'^authorizenet/', include('tendenci.apps.payments.authorizenet.urls')),
     (r'^firstdata/', include('tendenci.apps.payments.firstdata.urls')),
     (r'^firstdatae4/', include('tendenci.apps.payments.firstdatae4.urls')),

--- a/tendenci/apps/payments/urls.py
+++ b/tendenci/apps/payments/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import patterns, url, include
 
 urlpatterns = patterns('tendenci.apps.payments.views',
     url(r'^payonline/(?P<merchant_account>\w+)/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', 'pay_online', name="payment.pay_online"),
+    url(r'^payonline/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', 'pay_online', name="payment.pay_online"),
     (r'^authorizenet/', include('tendenci.apps.payments.authorizenet.urls')),
     (r'^firstdata/', include('tendenci.apps.payments.firstdata.urls')),
     (r'^firstdatae4/', include('tendenci.apps.payments.firstdatae4.urls')),


### PR DESCRIPTION
I'm looking to add multiple payment methods as per #531. This is an initial draft and I wouldn't mind a quick review before I proceed with further testing.

Essentially the approach is that instead of treating online payment as a single thing, the online payment view/URLconf now take a parameter with the `PaymentMethod.machine_name`. To use this, you would set up more than one `PaymentMethod` with `is_online` selected, eg. PayPal and Stripe.