### PR TITLE
Update NoDbTestRunner to support Django 1.8

### DIFF
--- a/tendenci/apps/base/test.py
+++ b/tendenci/apps/base/test.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.contrib.auth.models import User
 from django.conf import settings
 
 
-class NoDbTestRunner(DjangoTestSuiteRunner):
+class NoDbTestRunner(DiscoverRunner):
     """
     A test runner to test withouth database creation
     """


### PR DESCRIPTION
DjangoTestSuiteRunner is removed in Django 1.8 so NoDbTestRunner
has to be updated to a new testing mechanism.

I'm working on updates to the docs submitted in  #704 which includes
testing the tests.