### PR TITLE
Documentation sync between T7 and T11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,4 @@ For code style, please follow python [PEP 8](https://www.python.org/dev/peps/pep
 For front-end CSS, please adhere to the [Bootstrap CSS guidelines](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md#css).
 
 To help with the translations, please join us on transifex [https://www.transifex.com/tendenci/tendenci/](https://www.transifex.com/tendenci/tendenci/).
+

--- a/docs/source/contributing/testing.txt
+++ b/docs/source/contributing/testing.txt
@@ -1,0 +1,83 @@
+Testing changes to Tendenci
+===========================
+
+.. note:: Please consider adding tests if **adding or fixing** code in Tendenci!
+
+Testing during development is done via `Django style
+<https://docs.djangoproject.com/en/2.0/topics/testing/>`_ (Python) `unittest`
+tests.
+
+Testing can be done with the following steps and will test Tendenci as well as
+the basic project.
+
+Install Tendenci server
+-----------------------
+
+This is done following the install instructions, noting the following provisos:
+
+* After installing the requirements for Tendenci, upgrade the packaged Tendenci
+  to an editable checkout from git
+::
+
+  `pip install -e git+https://github.com/tendenci/tendenci.git@v7.5.0#egg=Tendenci`
+
+for a specific Tendenci version or for git head using the following
+::
+
+  `pip install -e git+https://github.com/tendenci/tendenci.git#egg=Tendenci`
+
+* While performing the database setup make sure your test name does not clash
+with your primary database. A also make the Tendenci user a database
+superuser (this is required to facilitate loading DB extensions in to test
+databases and should not be done in production environments).
+
+::
+
+  CREATE DATABASE <DB_NAME>_testsuite;
+  ALTER USER <DB_USER> SUPERUSER;
+
+
+Enable helpdesk
+---------------
+
+The commands below run all tendenci related tests including those of helpdesk
+which is disabled by default.
+
+To enable helpdesk app (and ensure its migrations are run) edit
+`conf/local_settings` and update INSTALLED_APPS.
+
+
+Running tests
+-------------
+
+Change in to the newly created site and run tests with
+
+::
+
+  python ./manage.py test tendenci --keepdb
+
+If coverage.py (a tool to measure the exposure of your codebase to tests) is
+installed it can also be used to provide reports
+
+::
+
+  coverage run --source='.' manage.py test tendenci --keepdb
+  coverage report
+
+Running with --keepdb is optional but speeds up Tendenci testing a lot due to
+its migration heavy nature but you will need to remove it if you see problems
+while running tests.
+
+--verbosity 2 can be used to increase output during testing.
+
+Note that when running `manage.py test` for the first time all migrations will
+need to be applied to the test database. If run with --keepdb that step will be
+skipped in future.
+
+Writing tests
+-------------
+
+`Django's documentation
+<https://docs.djangoproject.com/en/2.0/intro/tutorial05/>`_ covers writing
+tests and we recommend you look there for guidance.
+

--- a/docs/source/topic-guides/backup-and-restore.txt
+++ b/docs/source/topic-guides/backup-and-restore.txt
@@ -1,0 +1,96 @@
+On a production site taking backups and restoring them for testing/recovery
+purposes is a critical part of site setup and maintenance.
+
+Setting up a server to store your backups on is beyond the scope of this
+document, so here we cover automatically saving the data of your Tendenci site,
+plus its restoration.
+
+Backups
+=======
+
+A backup of Tendenci needs to be a copy of the website and database at a single
+point in time. For sites with predictable low activity periods a scheduled job
+to run early in the morning and perform the backup will be sufficient.
+
+Website
+-------
+
+Depending on your preferences, files can either be saved to an archive then
+synced to a backup location or simply copied there as a set of files.
+
+For automated backups, drop a script fragment in
+`/etc/cron.daily/tendenci-daily-backup.sh` and let cron take care of
+scheduling.
+
+
+Archiving before sending off site:
+
+::
+
+  tar -cjf /var/tmp/tendenci-nightly-backup.tar.bz2 /path/to/tendenci-website/
+  rsync --quiet /var/tmp/tendenci-nightly-backup.tar.bz2 user@remoteserver:/path/to/backups/
+
+Copying Tendenci directory directly:
+
+::
+
+  rsync --delete --quiet /path/to/tendenci-website/ user@remoteserver:/path/to/backup-tendenci-website
+
+
+Database
+--------
+
+As with the website files, this can be compressed or not but note for a
+moderately large site compression will save considerable amounts of space and
+network bandwidth.
+
+Backing up the databse (with compression) is a single command:
+
+::
+  sudo -u postgres pg_dump -Fc -f /tmp/tendenci-daily.sql postgres tendenci_db_name
+
+Or if compression isn't desirable:
+
+::
+
+  sudo -u postgres pg_dump tendenci > /tmp/tendenci-daily.sql
+
+Thile files can then be copied to the backup site:
+
+::
+
+  rsync --delete --quiet /path/to/tendenci-daily.sql user@remoteserver:/path/to/backup-tendenci-website
+
+Take care to keep the website and backup files in sync!
+
+
+Restore
+=======
+
+Restore is pretty much the same as the steps for installing, but with a couple of differences.
+
+Database
+--------
+
+Restoring is as easy as taking the backup was:
+
+::
+
+  rsync user@remoteserver:/path/to/backup-tendenci-website /path/to/tendenci-daily.sql
+  sudo -u postgres psql tendenci < /path/to/tendenci-daily.sql
+
+This should be done AFTER the DB setup steps in the install instructions.
+
+Website
+-------
+
+Restoring the website replaces the instructions on using tendenci-base-template
+and related install/configuration steps, but does not replace external setup
+like installing packages from pip or setting up Nginx.
+
+::
+
+  rsync user@remoteserver:/path/to/backup-tendenci-website /path/to/tendenci-website/
+
+
+

--- a/docs/source/topic-guides/discounts.txt
+++ b/docs/source/topic-guides/discounts.txt
@@ -1,0 +1,33 @@
+Discounts
+=========
+
+Setting up discount codes is a quick and painless process which can be applied to several apps within Tendenci.
+
+
+Enable discounts
+----------------
+
+Discounts come enabled by default, but check at https://example.com/settings/module/discounts/#id_enabled to ensure they are current set to 'enabled'.
+
+
+Configure discountable apps
+---------------------------
+
+Next configure the apps you would like to have discounts apply to - some examples below.
+
+Memberships
+^^^^^^^^^^^
+
+Make sure the "Discount eligible" is ticked on the relevant memberships applications (ex: https://www.example.com/admin/memberships/membershipapp/1/).
+
+Events
+^^^^^^
+
+To find the discount option tick 'Enable Registration' and make sure the "Discount eligible" is ticked when creating an Event (ex: https://demo.tendenci.com/events/add/ ).
+
+
+Adding discount codes
+---------------------
+
+Once the applications are configured to allow discounts they will appear in the 'Applications' list when issuing a discount code via https://www.example.com/discounts/add/ . Choose the applications you'd like to apply discounts to when creating the discount code.
+

--- a/docs/source/upgrade/upgrade-to-tendenci7.1.txt
+++ b/docs/source/upgrade/upgrade-to-tendenci7.1.txt
@@ -78,13 +78,13 @@ Step 3: Remove common addons modules from environment
 ---------------------------------------------------------------
 ::
 
-    pip uninstall tendenci-case-studies
-    pip uninstall tendenci-committees
-    pip uninstall tendenci-donations
-    pip uninstall tendenci-speakers
-    pip uninstall tendenci-staff
-    pip uninstall tendenci-studygroups
-    pip uninstall tendenci-videos
+    pip uninstall -y tendenci-case-studies
+    pip uninstall -y tendenci-committees
+    pip uninstall -y tendenci-donations
+    pip uninstall -y tendenci-speakers
+    pip uninstall -y tendenci-staff
+    pip uninstall -y tendenci-studygroups
+    pip uninstall -y tendenci-videos
 
 
 Step 4: Install requirements

--- a/docs/source/upgrade/upgrade-to-tendenci7.txt
+++ b/docs/source/upgrade/upgrade-to-tendenci7.txt
@@ -149,14 +149,14 @@ Step 4: Remove south and common addons modules from environment
 ---------------------------------------------------------------
 ::
 
-    pip uninstall South
-    pip uninstall tendenci-case-studies
-    pip uninstall tendenci-committees
-    pip uninstall tendenci-donations
-    pip uninstall tendenci-speakers
-    pip uninstall tendenci-staff
-    pip uninstall tendenci-studygroups
-    pip uninstall tendenci-videos
+    pip uninstall -y South
+    pip uninstall -y tendenci-case-studies
+    pip uninstall -y tendenci-committees
+    pip uninstall -y tendenci-donations
+    pip uninstall -y tendenci-speakers
+    pip uninstall -y tendenci-staff
+    pip uninstall -y tendenci-studygroups
+    pip uninstall -y tendenci-videos
 
 
 .. Note::


### PR DESCRIPTION
This pulls in all the easy changes I've made between the T11 and T7 branches. The install instructions have been extensively reworked by @PaulSD for T11 so I need to see how my updated docs compare to his and try to sync over only the required changes.
