### PR TITLE
Use Travis to do a test deploy of Tendenci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,63 @@
 language: python
 python:
   - "2.7"
-
+ 
+addons:
+  postgresql: "9.3"  
+  # https://github.com/travis-ci/travis-ci/issues/6972
+  apt:
+    packages:
+    - postgresql-9.3-postgis-2.3
+ 
 env:
   global:
+    # Work around boto issue https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882 , https://github.com/tendenci/tendenci/issues/539#issuecomment-345092987
+    - BOTO_CONFIG=/doesnotexist
     # for $TENDENCI_TRANSIFEX_PASSWORD
-    secure: "H3pfvt1czYywa1Fp+quLeWqHOTqZVXDeyoCAFCthi4FO7YYvj8FpaRefUJ8iBIpN/NKImJkGGAh10KWkWXwhwWf2IZQmjTpYRZ0EltkhLyHDIQugoKCnt6VSfPUcrBwZBbA5mBI1JWtSWuN6MnrwMbM9XPpYf4o85OpZZnBdCN8="
+    - secure: "H3pfvt1czYywa1Fp+quLeWqHOTqZVXDeyoCAFCthi4FO7YYvj8FpaRefUJ8iBIpN/NKImJkGGAh10KWkWXwhwWf2IZQmjTpYRZ0EltkhLyHDIQugoKCnt6VSfPUcrBwZBbA5mBI1JWtSWuN6MnrwMbM9XPpYf4o85OpZZnBdCN8="
+
+before_install:
+ - sudo apt-get -qq update
+ - sudo apt-get -qq install build-essential python-dev libevent-dev libpq-dev libjpeg8 libjpeg-dev libfreetype6 libfreetype6-dev
+ - sudo apt-get -qq install git
+ - sudo apt-get -qq install python-pip
 
 # command to install dependencies
 install:
-  - pip install "Django>=1.8,<1.9"
+ - cd ../..
+ - pwd
+ - pip install -q "Django>=1.8,<1.9"
+ - pip install -e goetzk/tendenci
+ - django-admin.py startproject --template=https://github.com/tendenci/tendenci-project-template/archive/master.zip testsuite_tendenci
+ - cd testsuite_tendenci
+ - pip install -r requirements/dev.txt
 
-# TODO: command to run tests
-# for now, run command to push source and translation files to Transifex
-script: ./transifex.sh
+before_script:
+ - psql -c "CREATE USER myprojectuser WITH PASSWORD 'passwordIsNotSecure';"
+ - psql -c "ALTER USER myprojectuser SUPERUSER;"
+ - psql -c "CREATE DATABASE tendenci_testsuite WITH OWNER myprojectuser;"
+ - psql -c "GRANT ALL PRIVILEGES ON DATABASE tendenci_testsuite TO myprojectuser;"
+ - psql -d tendenci_testsuite -c "CREATE EXTENSION postgis;"
+ - psql -d tendenci_testsuite -c "CREATE EXTENSION postgis_topology;"
+ - psql -d tendenci_testsuite -c "CREATE EXTENSION fuzzystrmatch;"
+ - psql -d tendenci_testsuite -c "CREATE EXTENSION postgis_tiger_geocoder;"
+ - sed -i -e 's/<DB_NAME>/tendenci_testsuite/g' conf/local_settings.py
+ - sed -i -e 's/<DB_USER>/myprojectuser/g' conf/local_settings.py
+ - sed -i -e 's/<DB_PASS>/passwordIsNotSecure/g' conf/local_settings.py
+ - echo -e "\nINSTALLED_APPS += ('markdown_deux', 'bootstrapform', 'tendenci.apps.helpdesk',)" >> conf/local_settings.py
+ 
+script:
+# TODO: do I need these three if running tests? logicall no because the tests build their own tables.
+ # Deploy Tendenci
+ - python manage.py migrate
+ - python deploy.py
+ - python manage.py load_creative_defaults
+ # Run tests
+ - python ./manage.py test --keepdb --verbosity 2
+# Enable once all tests pass
+# - python ./manage.py test tendenci --keepdb --verbosity 2
+
+# This could be done using after_script if successful tests aren't required
+after_success:
+ # Run command to push source and translation files to Transifex
+ - ./transifex.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
  - cd ../..
  - pip install -q "Django>=1.8,<1.9"
- - pip install -e goetzk/tendenci
+ - pip install -e $TRAVIS_BUILD_DIR
  - django-admin.py startproject --template=https://github.com/tendenci/tendenci-project-template/archive/master.zip testsuite_tendenci
  - cd testsuite_tendenci
  - pip install -r requirements/dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
 # command to install dependencies
 install:
  - cd ../..
- - pwd
  - pip install -q "Django>=1.8,<1.9"
  - pip install -e goetzk/tendenci
  - django-admin.py startproject --template=https://github.com/tendenci/tendenci-project-template/archive/master.zip testsuite_tendenci
@@ -46,7 +45,6 @@ before_script:
  - echo -e "\nINSTALLED_APPS += ('markdown_deux', 'bootstrapform', 'tendenci.apps.helpdesk',)" >> conf/local_settings.py
 
 script:
-# TODO: do I need these three if running tests? logicall no because the tests build their own tables.
  # Deploy Tendenci
  - python manage.py migrate
  - python deploy.py
@@ -54,10 +52,9 @@ script:
  # Run tests
  # - flake8
  - python ./manage.py test --keepdb --verbosity 2
-# Enable once all tests pass
 # - python ./manage.py test tendenci --keepdb --verbosity 2
 
-# This could be done using after_script if successful tests aren't required
 after_success:
  # Run command to push source and translation files to Transifex
  - ./transifex.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ env:
 before_install:
  - sudo apt-get -qq update
  - sudo apt-get -qq install build-essential python-dev libevent-dev libpq-dev libjpeg8 libjpeg-dev libfreetype6 libfreetype6-dev
- - sudo apt-get -qq install git
- - sudo apt-get -qq install python-pip
+ - sudo apt-get -qq install git python-flake8 python-pip
 
 # command to install dependencies
 install:
@@ -53,6 +52,7 @@ script:
  - python deploy.py
  - python manage.py load_creative_defaults
  # Run tests
+ # - flake8
  - python ./manage.py test --keepdb --verbosity 2
 # Enable once all tests pass
 # - python ./manage.py test tendenci --keepdb --verbosity 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 python:
   - "2.7"
- 
+
 addons:
-  postgresql: "9.3"  
+  postgresql: "9.3"
   # https://github.com/travis-ci/travis-ci/issues/6972
   apt:
     packages:
     - postgresql-9.3-postgis-2.3
- 
+
 env:
   global:
     # Work around boto issue https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882 , https://github.com/tendenci/tendenci/issues/539#issuecomment-345092987
@@ -45,7 +45,7 @@ before_script:
  - sed -i -e 's/<DB_USER>/myprojectuser/g' conf/local_settings.py
  - sed -i -e 's/<DB_PASS>/passwordIsNotSecure/g' conf/local_settings.py
  - echo -e "\nINSTALLED_APPS += ('markdown_deux', 'bootstrapform', 'tendenci.apps.helpdesk',)" >> conf/local_settings.py
- 
+
 script:
 # TODO: do I need these three if running tests? logicall no because the tests build their own tables.
  # Deploy Tendenci


### PR DESCRIPTION
To help with the move towards automated testing I wrote 
this travis configuration which does everything except run
the actual Tendenci tests (commented out on line 58).

Because the tests currently fail (on T7 there are 20 failures
and 38 errors) I've left the tests commented out but they're
easy enough to reenable if desired.

Note also that per #712 transifex is still run, this time assuming successful
deployment but that could also be changed to after_script which
would ignore the output of the deployment.

Finally, this is marked WIP because @PaulSD suggested I add
flake8 to the test queue and I haven't done that yet.