### PR TITLE
Exclude __pycache__ folder from addons directory

### DIFF
--- a/tendenci/apps/registry/utils.py
+++ b/tendenci/apps/registry/utils.py
@@ -36,7 +36,7 @@ def custom_choices(addon_folder_path):
     Returns a list of available addons in the tendenci-site wrapper app
     """
     for addon in os.listdir(addon_folder_path):
-        if os.path.isdir(os.path.join(addon_folder_path, addon)):
+        if os.path.isdir(os.path.join(addon_folder_path, addon)) and addon not in ['__pycache__']:
             yield addon
 
 


### PR DESCRIPTION
Python creates a dummy directory` __pycache__` which is picked up by the Tendenci addon parser, this is a simple fix, to make sure it's omitted from the list of addons.