### PR TITLE
memberships: Allow multiple online payment methods in application form.

### DIFF
--- a/tendenci/apps/memberships/views.py
+++ b/tendenci/apps/memberships/views.py
@@ -1274,9 +1274,10 @@ def membership_default_add(request, slug='', membership_id=None,
 
             # redirect: payment gateway
             if membership_set.is_paid_online():
+                merchant_account = membership_form2.cleaned_data['payment_method'].machine_name
                 return HttpResponseRedirect(reverse(
                     'payment.pay_online',
-                    args=[invoice.pk, invoice.guid]
+                    args=[merchant_account, invoice.pk, invoice.guid]
                 ))
 
             # redirect: membership edit page

--- a/tendenci/apps/payments/urls.py
+++ b/tendenci/apps/payments/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url, include
 from . import views
 
 urlpatterns = [
+    url(r'^payonline/(?P<merchant_account>\w+)/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', views.pay_online, name="payment.pay_online"),
     url(r'^payonline/(?P<invoice_id>\d+)/(?P<guid>[\d\w-]+)?$', views.pay_online, name="payment.pay_online"),
     url(r'^authorizenet/', include('tendenci.apps.payments.authorizenet.urls')),
     url(r'^firstdata/', include('tendenci.apps.payments.firstdata.urls')),

--- a/tendenci/apps/payments/views.py
+++ b/tendenci/apps/payments/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseRedirect
@@ -14,7 +16,10 @@ from tendenci.apps.event_logs.models import EventLog
 from tendenci.apps.site_settings.utils import get_setting
 
 
-def pay_online(request, invoice_id, guid="", template_name="payments/pay_online.html"):
+logger = logging.getLogger(__name__)
+
+
+def pay_online(request, invoice_id, guid="", merchant_account=None, template_name="payments/pay_online.html"):
     # check if they have the right to view the invoice
     invoice = get_object_or_404(Invoice, pk=invoice_id)
     if not invoice.allow_view_by(request.user, guid):
@@ -35,7 +40,7 @@ def pay_online(request, invoice_id, guid="", template_name="payments/pay_online.
 
     # post payment form to gateway and redirect to the vendor so customer can pay from there
     if boo:
-        merchant_account = (get_setting("site", "global", "merchantaccount")).lower()
+        merchant_account = merchant_account or (get_setting("site", "global", "merchantaccount")).lower()
 
         if merchant_account == 'stripe':
             return HttpResponseRedirect(reverse('stripe.payonline', args=[payment.id]))
@@ -61,6 +66,9 @@ def pay_online(request, invoice_id, guid="", template_name="payments/pay_online.
                 form = prepare_paypal_form(request, payment)
                 post_url = settings.PAYPAL_POST_URL
             else:   # more vendors
+                logger.error(
+                    '"{}" did not match a known online payment method. Check the PaymentMethod.machine_name.'.format(
+                        merchant_account))
                 form = None
                 post_url = ""
     else:


### PR DESCRIPTION
(This is a new copy of reverted commit c16e8aa relating to #686.)

Instead of assuming a single online payment method configured in settings, this approach passes the relevant `PaymentMethod.machine_name` through to the `pay_online` view. To use this, set up more than one `PaymentMethod` with `is_online` selected, eg. PayPal and Stripe.

If no specific payment method is passed, `pay_online` will use the default specified in the `merchantaccount` setting.

Requirements:

1. Global Merchant Account setting configured, eg. "stripe". Visit: /settings/site/global/#id_merchantaccount

2. Multiple PaymentMethods configured with "is_online" selected. Importantly, use the gateway module name as the "machine name". Can be one of "stripe", "paypal", "authorizenet", "firstdata", "firstdatae4" or "payflowlink". Visit: /admin/payments/paymentmethod/

3. Enable the relevant payment methods on the Membership Application. Visit: /admin/memberships/membershipapp/