### PR TITLE
Pin django-debug-toolbar version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-simple-captcha==0.5.5
 django-nocaptcha-recaptcha==0.0.20
 django-tagging==0.4.3
 django-haystack==2.4.1
-django-debug-toolbar>=1.2.2
+django-debug-toolbar==1.9.1
 django-sql-explorer==0.9.2
 feedparser>=4.1
 httplib2>=0.4.0


### PR DESCRIPTION
This PR pins the django-debug-toolbar package to version 1.9.1.

The 1.10 version of the django-debug-toolbar package was [released yesterday](https://django-debug-toolbar.readthedocs.io/en/stable/changes.html) and it's not Django 1.8 compatible which breaks new Tendenci 7 installations.

These are today screenshots from two of our set up scripts showing the problem:

![blome59](https://user-images.githubusercontent.com/560781/45183540-9e83dd00-b1e1-11e8-95f1-c676792045be.png)

![gtahveq](https://user-images.githubusercontent.com/560781/45183575-b5c2ca80-b1e1-11e8-9bad-b60799382cbd.png)
