### PR TITLE
slug validator added to GroupForm

### DIFF
--- a/tendenci/apps/user_groups/forms.py
+++ b/tendenci/apps/user_groups/forms.py
@@ -11,6 +11,7 @@ from tendenci.apps.user_groups.utils import member_choices
 from tendenci.apps.perms.forms import TendenciBaseForm
 from tendenci.apps.entities.models import Entity
 from tendenci.apps.site_settings.utils import get_setting
+from tendenci.apps.base.fields import SlugField
 
 
 SEARCH_CATEGORIES = (
@@ -104,6 +105,8 @@ class GroupForm(TendenciBaseForm):
         help_text=_('Display this group as an option to logged-in users.'),
         required=False)
     status_detail = forms.ChoiceField(choices=STATUS_CHOICES)
+
+    slug = forms.SlugField(label=_("URL Path")) 
 
     class Meta:
         model = Group

--- a/tendenci/apps/user_groups/forms.py
+++ b/tendenci/apps/user_groups/forms.py
@@ -11,7 +11,6 @@ from tendenci.apps.user_groups.utils import member_choices
 from tendenci.apps.perms.forms import TendenciBaseForm
 from tendenci.apps.entities.models import Entity
 from tendenci.apps.site_settings.utils import get_setting
-from tendenci.apps.base.fields import SlugField
 
 
 SEARCH_CATEGORIES = (


### PR DESCRIPTION
Hello, I was testing your demo tendenci groups, and I found an issues with the **"URL PATH"**, when you try to use **'/'** in the text field and it displays an **"Oops admin error"**. 

![screenshot-demo tendenci com-2018 09 25-22-09-02](https://user-images.githubusercontent.com/19859884/46057319-538b2480-c112-11e8-9dd3-62c2b90a091b.png)


so, I try to make a fix for that using **_forms.py_** in **user_groups app folder** adding these lines of code

`from tendenci.apps.base.fields import SlugField` **to import tendenci SlugField from tendenci**

**and added this line to class _GroupForm(TendenciBaseForm)_**

`slug = forms.SlugField(label=_("URL Path")) ` 

that works for me but, I'd like to know if you have some advices to fix it properly.






