### PR TITLE
users can or cannot remove themselves from groups Fixed

### DIFF
--- a/tendenci/apps/user_groups/templates/user_groups/detail.html
+++ b/tendenci/apps/user_groups/templates/user_groups/detail.html
@@ -58,7 +58,7 @@
                         {% blocktrans %}Users cannot add themselves to this group{% endblocktrans %}</a></li>
                 {% endif %}
 
-                {% if group.allow_self.remove %}
+                {% if group.allow_self_remove %}
                     <li><a href="{% url "group.edit" group.slug %}">
                         {% blocktrans %}Users can remove themselves from this group{% endblocktrans %}</a></li>
                 {% else %}


### PR DESCRIPTION
Hello, I found this little issue in groups when I tried to change their options for users.
after creating one group page, it shows a sidebar that says:

- Users can add themselves to this group
- Users cannot remove themsleves

This issue causes that if you click on **"Users cannot remove 'themsleves'"** you'll see a check box next to "Allow self remove" which is checked / selected. you would interpret this as meaning **"users CAN remove 'themsleves'"** but this option unfortunately doesn't work.

I found the issue in _**user_groups app**_ > templates > **"detail.html"** template
```html
{% if group.allow_self.remove %}
<li><a href="{% url " group.edit" group.slug %}">
    {% blocktrans %}Users can remove themselves from this group{% endblocktrans %}</a></li>
{% else %}
```
I found the problem and it's fixed now.

changes: **"{% if group.allow_self_remove %}"** dot removed and underscore added.

```html
{% if group.allow_self_remove %}
<li><a href="{% url " group.edit" group.slug %}">
    {% blocktrans %}Users can remove themselves from this group{% endblocktrans %}</a></li>
{% else %}
```
