### PR TITLE
Fix event registration statistics display

### DIFF
--- a/tendenci/themes/t7-base/templates/events/include/spots_status.html
+++ b/tendenci/themes/t7-base/templates/events/include/spots_status.html
@@ -1,5 +1,5 @@
 {% if event.limit > 0 and event.spots_available != -1 %}
 {% if user.profile.is_superuser or event.registration_configuration.display_registration_stats %}
-<div class="spots-status">{% blocktrans with sp=spots_available|pluralize %}{{ spots_taken }} registered. {{ spots_available }} spot{{ sp }} left{% endblocktrans %}</div>
+<div class="spots-status">{{ event.spots_taken }} registered. {{ event.spots_available }} {% blocktrans with sp=event.spots_available|pluralize %}spot{{ sp }} left{% endblocktrans %}</div>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
variables seem to go out of scope within 'blocktrans' so tighten the
'blocktrans' to just the pluralisation section.