### PR TITLE
Fix recurring_payments test

### DIFF
--- a/tendenci/apps/base/management/commands/run_nightly_commands.py
+++ b/tendenci/apps/base/management/commands/run_nightly_commands.py
@@ -2,7 +2,6 @@
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
-from django.conf import settings
 
 
 class Command(BaseCommand):
@@ -11,8 +10,6 @@ class Command(BaseCommand):
     nightly (daily) basis.
     """
     def handle(self, *args, **options):
-        from tendenci.apps.site_settings.utils import get_setting
-
         commands = ('expire_jobs',
                     'expire_resumes',
                     'expire_stories',
@@ -30,15 +27,10 @@ class Command(BaseCommand):
                     'captcha_clean',
                     'cleanup_expired_dbdumps',
                     'clearsessions',
+                    'make_recurring_payment_transactions',
                     )
         for c in commands:
             try:
                 call_command(c)
             except:
                 pass
-
-        if all([get_setting('module', 'recurring_payments', 'enabled'),
-                getattr(settings, 'MERCHANT_LOGIN', ''),
-                getattr(settings, 'MERCHANT_TXN_KEY', '')
-                ]):
-            call_command('make_recurring_payment_transactions')

--- a/tendenci/apps/recurring_payments/management/commands/make_recurring_payment_transactions.py
+++ b/tendenci/apps/recurring_payments/management/commands/make_recurring_payment_transactions.py
@@ -14,8 +14,7 @@ def _check_stripe():
     return _verify_settings('STRIPE_SECRET_KEY', 'STRIPE_PUBLISHABLE_KEY')
 
 def _check_authorize_net():
-    return _verify_settings('MERCHANT_LOGIN', 'MERCHANT_TXN_KEY',
-                            'AUTHNET_MD5_HASH_VALUE')
+    return _verify_settings('MERCHANT_LOGIN', 'MERCHANT_TXN_KEY')
 
 def has_supported_merchant_account(platform):
     if platform == 'authorizenet':


### PR DESCRIPTION
The command 'make_recurring_payment_transactions' would only run if
MERCHANT_LOGIN and MERCHANT_TXN_KEY resolved to True (i.e. weren't the
blank string or undefined). This now checks for all the combinations
of variables required by each merchant provider and fixes the bug
where a valid provider has been set up but the payments were not
processed regularly.