### PR TITLE
Remove problematic check on self.user (bug #811)

### DIFF
--- a/tendenci/apps/emails/models.py
+++ b/tendenci/apps/emails/models.py
@@ -159,16 +159,13 @@ class Email(TendenciBaseModel):
         if user2_compare.profile.is_superuser:
             boo = True
         else:
-            if user2_compare == self.user:
-                boo = True
+            if user2_compare == self.creator or user2_compare == self.owner:
+                if self.status:
+                    boo = True
             else:
-                if user2_compare == self.creator or user2_compare == self.owner:
+                if user2_compare.has_perm('emails.edit_email', self):
                     if self.status:
                         boo = True
-                else:
-                    if user2_compare.has_perm('emails.edit_email', self):
-                        if self.status:
-                            boo = True
         return boo
 
     def template_body(self, email_d):


### PR DESCRIPTION
For reasons unknown a check was being performed on self.user, which doesn't exist in the email
class.
Here we remove that check and the associated if statement to allow the code to continue checking. As tested by my customer, this now works for non staff usres. I'm not sure why this broke since a look at the histories for Email and TendenciBaseModel show no changes to add/remove a user attribute for at least 5 years. 

This is resolves Tendenci #811 