### PR TITLE
Allow Pages and Stories to appear in apps menu

### DIFF
--- a/tendenci/themes/t8-base/templates/top_menu/_apps_dropdown.html
+++ b/tendenci/themes/t8-base/templates/top_menu/_apps_dropdown.html
@@ -91,22 +91,20 @@
                                     <div class="panel-body">
                                         <div class="row">
                                             <ul class="list-unstyled col-sm-6 col-xs-12">
-                                            {% if USER_IS_SUPERUSER %}
-                                                {% if MODULE_PAGES_ENABLED %}
-                                                    <li class="content-item">
-                                                        <a href="{% url 'pages' %}"
-                                                            ><img class="nav-icon" src="{% static 'famfamfam/icons/page_white_stack.png' %}"/><span class="nav-label">{% firstof MODULE_PAGES_LABEL_PLURAL trans "Pages" %}</span>
-                                                        </a>
-                                                    </li>
-                                                {% endif %}
+                                            {% if MODULE_PAGES_ENABLED %}
+                                                <li class="content-item">
+                                                    <a href="{% url 'pages' %}"
+                                                        ><img class="nav-icon" src="{% static 'famfamfam/icons/page_white_stack.png' %}"/><span class="nav-label">{% firstof MODULE_PAGES_LABEL_PLURAL trans "Pages" %}</span>
+                                                    </a>
+                                                </li>
+                                            {% endif %}
 
-                                                {% if MODULE_STORIES_ENABLED %}
-                                                    <li class="content-item">
-                                                        <a href="{% url 'stories' %}"
-                                                            ><img class="nav-icon" src="{% static 'famfamfam/icons/book_open.png' %}"/><span class="nav-label">{% firstof MODULE_STORIES_LABEL_PLURAL trans "Stories" %}</span>
-                                                        </a>
-                                                    </li>
-                                                {% endif %}
+                                            {% if MODULE_STORIES_ENABLED %}
+                                                <li class="content-item">
+                                                    <a href="{% url 'stories' %}"
+                                                        ><img class="nav-icon" src="{% static 'famfamfam/icons/book_open.png' %}"/><span class="nav-label">{% firstof MODULE_STORIES_LABEL_PLURAL trans "Stories" %}</span>
+                                                    </a>
+                                                </li>
                                             {% endif %}
 
                                                 {% if MODULE_NEWS_ENABLED %}


### PR DESCRIPTION
Currently the Pages and Stories apps are restricted in the Apps navigation menu to
those with superuser access but its not actually required. All users are able
to search - indeed the Pages app displays in the top bar anyway - and should be
able to add pages with appropriate permissions in place.

This change removes the navigational restriction on non superusers.

I haven't had a chance to test this yet so there may be follow up commits.