### PR TITLE
Synchronise t7 and t8 _apps_dropdown.html

### DIFF
--- a/tendenci/themes/t7-base/templates/top_menu/_apps_dropdown.html
+++ b/tendenci/themes/t7-base/templates/top_menu/_apps_dropdown.html
@@ -91,22 +91,20 @@
                                     <div class="panel-body">
                                         <div class="row">
                                             <ul class="list-unstyled col-sm-6 col-xs-12">
-                                            {% if USER_IS_SUPERUSER %}
-                                                {% if MODULE_PAGES_ENABLED %}
-                                                    <li class="content-item">
-                                                        <a href="{% url 'pages' %}"
-                                                            ><img class="nav-icon" src="{% static 'famfamfam/icons/page_white_stack.png' %}"/><span class="nav-label">{% trans "Pages" %}</span>
-                                                        </a>
-                                                    </li>
-                                                {% endif %}
+                                            {% if MODULE_PAGES_ENABLED %}
+                                                <li class="content-item">
+                                                    <a href="{% url 'pages' %}"
+                                                        ><img class="nav-icon" src="{% static 'famfamfam/icons/page_white_stack.png' %}"/><span class="nav-label">{% firstof MODULE_PAGES_LABEL_PLURAL trans "Pages" %}</span>
+                                                    </a>
+                                                </li>
+                                            {% endif %}
 
-                                                {% if MODULE_STORIES_ENABLED %}
-                                                    <li class="content-item">
-                                                        <a href="{% url 'stories' %}"
-                                                            ><img class="nav-icon" src="{% static 'famfamfam/icons/book_open.png' %}"/><span class="nav-label">{% firstof MODULE_STORIES_LABEL_PLURAL trans "Stories" %}</span>
-                                                        </a>
-                                                    </li>
-                                                {% endif %}
+                                            {% if MODULE_STORIES_ENABLED %}
+                                                <li class="content-item">
+                                                    <a href="{% url 'stories' %}"
+                                                        ><img class="nav-icon" src="{% static 'famfamfam/icons/book_open.png' %}"/><span class="nav-label">{% firstof MODULE_STORIES_LABEL_PLURAL trans "Stories" %}</span>
+                                                    </a>
+                                                </li>
                                             {% endif %}
 
                                                 {% if MODULE_NEWS_ENABLED %}
@@ -372,7 +370,7 @@
                                                         ><img class="nav-icon" src="{% static 'famfamfam/icons/report.png' %}"/><span class="nav-label">{% trans 'Invoicing Reports' %}</span>
                                                     </a>
                                                 </li>
-                                                
+
                                                 {% if MODULE_MAKE_PAYMENT_ENABLED %}
                                                     <li class="content-item">
                                                         <a href="{% url 'make_payment.add' %}"

--- a/tendenci/themes/t8-base/templates/top_menu/_apps_dropdown.html
+++ b/tendenci/themes/t8-base/templates/top_menu/_apps_dropdown.html
@@ -370,6 +370,14 @@
                                                         ><img class="nav-icon" src="{% static 'famfamfam/icons/report.png' %}"/><span class="nav-label">{% trans 'Invoicing Reports' %}</span>
                                                     </a>
                                                 </li>
+
+                                                {% if MODULE_MAKE_PAYMENT_ENABLED %}
+                                                    <li class="content-item">
+                                                        <a href="{% url 'make_payment.add' %}"
+                                                            ><img class="nav-icon" src="{% static 'famfamfam/icons/money.png' %}"/><span class="nav-label">{% trans 'Make Payment' %}</span>
+                                                        </a>
+                                                    </li>
+                                                {% endif %}
                                             </ul>
                                             <ul class="list-unstyled col-sm-6 col-xs-12">
                                                 {% if MODULE_DISCOUNTS_ENABLED %}


### PR DESCRIPTION
Based on feedback in #817 I've brought T7 and T8 theme
_top_menu/_apps_dropdown.html files in sync.

In practical terms this means Pages and Stories will show even when the user is
not root and the t8 theme now has a 'Make payment' link in the finances section.