### PR TITLE
Fixes #864

### DIFF
--- a/tendenci/apps/accounts/forms.py
+++ b/tendenci/apps/accounts/forms.py
@@ -32,6 +32,9 @@ class SetPasswordCustomForm(SetPasswordForm):
         super(SetPasswordCustomForm, self).__init__(*args, **kwargs)
 
         self.fields['new_password1'].widget = forms.PasswordInput(attrs={'class': 'form-control'})
+        password_requirements = get_setting('module', 'users', 'password_text')
+        if password_requirements:
+            self.fields['new_password1'].help_text = password_requirements
         self.fields['new_password2'].widget = forms.PasswordInput(attrs={'class': 'form-control'})
 
     def clean_new_password1(self):
@@ -64,6 +67,9 @@ class RegistrationCustomForm(RegistrationForm):
         self.allow_same_email = kwargs.pop('allow_same_email', False)
 
         super(RegistrationCustomForm, self).__init__(*args, **kwargs)
+        password_requirements = get_setting('module', 'users', 'password_text')
+        if password_requirements:
+            self.fields['password1'].help_text = password_requirements
 
     def clean_password1(self):
         password1 = self.cleaned_data.get('password1')


### PR DESCRIPTION
This fix to accounts/forms.py passes the site setting for "Password Requirements Description" (https://my-tendenci-site.org.au/settings/module/users/%23id_password_text) through to the https://my-tendenci-site.org.au/accounts/register/ page so that is displayed instead of the hard-coded default setting which seems to have been locked in previously.

It would be good also if the "Change Password" page (https://my-tendenci-site.org.au/accounts/password/change/1/) could also be modified to display the "Password Requirements Description" value as help text.  One of the changes I've made to accounts/forms.py should enable this to happen, however the [template change](https://github.com/tendenci/tendenci/blob/master/tendenci/themes/t7-base/templates/registration/custom_password_change_form.html) looks a bit more complex than my primitive Tendenci knowledge can cope with at this stage!