### PR TITLE
Add OpenOffice file formats, remove ppt

### DIFF
--- a/tendenci/apps/files/utils.py
+++ b/tendenci/apps/files/utils.py
@@ -540,7 +540,7 @@ def get_max_file_upload_size(file_module=False):
 def get_allowed_upload_file_exts(file_type='other'):
     types = {'image': ('.gif', '.jpeg', '.jpg', '.png', '.tif', '.tiff', '.bmp'),
              'video': ('.wmv', '.mov', '.mpg', '.mp4', '.m4v'),
-             'other': ('.txt', '.docx', '.csv', '.xlsx', '.ppt', '.pptx', '.pps', '.ppsx', '.vcf', '.pdf', '.zip'),
+             'other': ('.txt', '.docx', '.csv', '.xlsx', '.pptx', '.pps', '.ppsx', '.vcf', '.pdf', '.zip', '.odt', '.ods', '.odp'),
              }
     if settings.ALLOW_MP3_UPLOAD:
         types['other'] += ('.mp3',)


### PR DESCRIPTION
fix #854
Added OpenOffice / LibreOffice file types - document, spreadsheet, presentation. 

Also removed .ppt.  If we are not allowing .doc and .xls because of potential vulnerabilities / software EOL then it makes sense to also drop support for .ppt. 