### PR TITLE
Fix corporate_membership file import issue

### DIFF
--- a/tendenci/apps/corporate_memberships/forms.py
+++ b/tendenci/apps/corporate_memberships/forms.py
@@ -922,7 +922,7 @@ class CorpMembershipUploadForm(forms.ModelForm):
         if not key:
             raise forms.ValidationError(_('Please specify the key to identify duplicates'))
 
-        file_content = upload_file.read()
+        file_content = upload_file.read().decode('utf-8')
         upload_file.seek(0)
         header_line_index = file_content.find('\n')
         header_list = ((file_content[:header_line_index]


### PR DESCRIPTION
header validation steps in function clean_upload_file are expecting a string for comparison to a string.  Instead we were attempting to compare a bytes object to a string.  
Closes #890 