### PR TITLE
fix profile/add form username limits

### DIFF
--- a/tendenci/apps/profiles/forms.py
+++ b/tendenci/apps/profiles/forms.py
@@ -153,7 +153,7 @@ class ProfileForm(TendenciBaseForm):
                                widget=forms.TextInput(attrs={'size':'30'}))
 
     username = forms.RegexField(regex=r'^[\w.@+-]+$',
-                                max_length=30,
+                                max_length=150,
                                 widget=forms.TextInput(attrs=attrs_dict),
                                 label=_(u'Username'),
                                 help_text = _("Required. Allowed characters are letters, digits, at sign (@), period (.), plus sign (+), dash (-), and underscore (_)."),
@@ -396,10 +396,10 @@ class ProfileAdminForm(TendenciBaseForm):
     email2 = EmailVerificationField(label=_("Secondary Email"), required=False)
 
     username = forms.RegexField(regex=r'^[\w.@+-]+$',
-                                max_length=30,
+                                max_length=150,
                                 widget=forms.TextInput(attrs=attrs_dict),
                                 label=_(u'Username'),
-                                help_text = _("Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."))
+                                help_text = _("Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."))
     password1 = forms.CharField(label=_("Password"), widget=forms.PasswordInput(attrs=attrs_dict))
     password2 = forms.CharField(label=_("Password (again)"), widget=forms.PasswordInput(attrs=attrs_dict),
         help_text = _("Enter the same password as above, for verification."))
@@ -872,4 +872,4 @@ class UserUploadForm(forms.ModelForm):
 class ActivateForm(forms.Form):
     email = forms.CharField(max_length=75)
     username = forms.RegexField(regex=r'^[\w.@+-]+$',
-                                max_length=30, required=False)
+                                max_length=150, required=False)


### PR DESCRIPTION
The add member form at /profile/add restricts usernames to 30 characters or less.  This updates the form to match the global username limit of 150 characters. 