### PR TITLE
enable user to edit directory they are member of

### DIFF
--- a/tendenci/apps/directories/templatetags/directory_tags.py
+++ b/tendenci/apps/directories/templatetags/directory_tags.py
@@ -12,7 +12,8 @@ register = Library()
 def directory_options(context, user, directory):
     context.update({
         "opt_object": directory,
-        "user": user
+        "user": user,
+        "is_member_of_directory": directory.has_membership_with(user)
     })
     return context
 

--- a/tendenci/themes/t7-base/templates/directories/options.html
+++ b/tendenci/themes/t7-base/templates/directories/options.html
@@ -1,7 +1,8 @@
 {% load base_tags %}
 {% load perm_tags %}
 
-{% has_perm user directories.change_directory opt_object as can_edit %}
+{% has_perm user directories.change_directory opt_object as has_edit_dir_perm %}
+{% has_edit_dir_perm or is_member_of_directory as can_edit %}
 {% has_perm user directories.delete_directory opt_object as can_delete %}
 
 <div class="t-iconrow">


### PR DESCRIPTION
Currently users are permitted to edit their directory listing based on two criteria: 
https://github.com/tendenci/tendenci/blob/7f7b2736b9030a2b0b41fda78532cc65a7a9b40a/tendenci/apps/directories/views.py#L236-L237

The template for the options menu only shows the edit button if the user has permission 'directories.change_directory', it does not check for membership.  
https://github.com/tendenci/tendenci/blob/7f7b2736b9030a2b0b41fda78532cc65a7a9b40a/tendenci/themes/t7-base/templates/directories/options.html#L4

This adds a check for membership and displays the edit button in the options menu if the user is a member of the entity, on the details page. 