### PR TITLE
truncate extended for directories/marketplace search results

### DIFF
--- a/tendenci/themes/t7-base/templates/directories/search-result.html
+++ b/tendenci/themes/t7-base/templates/directories/search-result.html
@@ -55,9 +55,9 @@
       
       <p class="item-content">
         {% if directory.summary %}
-        {{ directory.summary|striptags|truncatewords:15|safe }}
+        {{ directory.summary|striptags|truncatewords:50|safe }}
         {% else %}
-        {{ directory.body|striptags|truncatewords:15|safe }}
+        {{ directory.body|striptags|truncatewords:50|safe }}
         {% endif %}
       </p>
     </div>


### PR DESCRIPTION
Search results currently leave a lot of empty space in the tiles.  
<img width="297" alt="image" src="https://user-images.githubusercontent.com/56141128/100473543-9e1ad980-30ac-11eb-84ec-d490086a9e5e.png">

This extends the text to fill the tile. 