### PR TITLE
django_ses.SESBackend conditional added to newletter relay function

### DIFF
--- a/tendenci/apps/newsletters/utils.py
+++ b/tendenci/apps/newsletters/utils.py
@@ -58,9 +58,14 @@ def get_newsletter_connection():
 
 
 def is_newsletter_relay_set():
-    return all([settings.NEWSLETTER_EMAIL_HOST,
-                settings.NEWSLETTER_EMAIL_HOST_USER,
-                settings.NEWSLETTER_EMAIL_HOST_PASSWORD])
+    connection = settings.NEWSLETTER_EMAIL_BACKEND
+    if connection == "django_ses.SESBackend":
+        return all([settings.AWS_ACCESS_KEY_ID,
+                    settings.AWS_SECRET_ACCESS_KEY])
+    else:
+        return all([settings.NEWSLETTER_EMAIL_HOST,
+                    settings.NEWSLETTER_EMAIL_HOST_USER,
+                    settings.NEWSLETTER_EMAIL_HOST_PASSWORD])
 
 
 def newsletter_articles_list(request, articles_days, simplified):


### PR DESCRIPTION
In settings.py, you could had the option to use Amazon SES for the Newsletter backend but there were only checks for the SMTP. If you did not have an SMTP configuration but instead use SES, the send fails and you get the error:
 'Email relay is not configured properly.' 

This commit adds a small check to the `is_newsletter_relay_set function` to see if SES is set (`NEWSLETTER_EMAIL_BACKEND = django_ses.SESBackend` in `settings.py`) and returns true if `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` are configured in `settings.py.`