### PR TITLE
Fixes #1026 - Retrieve full details of models when querying events API

### DIFF
--- a/tendenci/apps/api_tasty/events/resources.py
+++ b/tendenci/apps/api_tasty/events/resources.py
@@ -19,9 +19,9 @@ class TypeResource(ModelResource):
         detail_allowed_methods = ['get',]
 
 class EventResource(TendenciResource):
-    entity = fields.ForeignKey(EntityResource, 'entity', null=True)
-    type = fields.ForeignKey(TypeResource, 'type', null=True)
-    place = fields.ForeignKey(PlaceResource, 'place', null=True)
+    entity = fields.ForeignKey(EntityResource, 'entity', null=True, full=True)
+    type = fields.ForeignKey(TypeResource, 'type', null=True, full=True)
+    place = fields.ForeignKey(PlaceResource, 'place', null=True, full=True)
 
     class Meta(TendenciResource.Meta):
         queryset = Event.objects.filter(status=True)

--- a/tendenci/apps/api_tasty/resources.py
+++ b/tendenci/apps/api_tasty/resources.py
@@ -7,8 +7,8 @@ from tendenci.apps.api_tasty.auth import DeveloperApiKeyAuthentication
 from tendenci.apps.api_tasty.users.resources import UserResource
 
 class TendenciResource(ModelResource):
-    owner = fields.ForeignKey(UserResource, 'owner', null=True)
-    creator = fields.ForeignKey(UserResource, 'creator', null=True)
+    owner = fields.ForeignKey(UserResource, 'owner', null=True, full=True)
+    creator = fields.ForeignKey(UserResource, 'creator', null=True, full=True)
 
     class Meta:
         #abstract = True


### PR DESCRIPTION
As advised by @jennyq, this should return all the data about an event including the location.