### PR TITLE
Remove deprecated CAPTCHA_OUTPUT_FORMAT setting.

### DIFF
--- a/tendenci/settings.py
+++ b/tendenci/settings.py
@@ -709,7 +709,6 @@ MERCHANT_ACCOUNT_NAMES = ('stripe', 'authorizenet', 'firstdatae4', 'paypal')
 CAPTCHA_FONT_SIZE = 50
 CAPTCHA_CHALLENGE_FUNCT = 'captcha.helpers.random_char_challenge'
 CAPTCHA_IMAGE_SIZE = (172,80)
-CAPTCHA_OUTPUT_FORMAT = u'%(image)s <br />%(hidden_field)s %(text_field)s'
 
 # Google reCAPTCHA
 NORECAPTCHA_SITE_KEY = ''


### PR DESCRIPTION
Currently when running Tendenci 12.5.8, I get a warning:

```
021-08-13 15:10:17 WARNING py.warnings: /home/ben/.virtualenvs/itpa-django-py38/lib/python3.8/site-packages/captcha/conf/settings.py:34: DeprecationWarning: CAPTCHA_OUTPUT_FORMAT setting is deprecated in favor of widget's template_name.
  warnings.warn(msg, DeprecationWarning)
```

After this change, the CAPTCHA still shows correctly on membership application form, but the warning is no longer present.

(I _think_ my `$PYTHONWARNINGS` are the default, but I have have inadvertently increased the warning level somewhere.)

![2021-08-13_15-20](https://user-images.githubusercontent.com/9541562/129308981-c21715f7-132a-40b8-af37-1e078f902a58.png)
