### PR TITLE
Return 500 status code on an unhandled exception.

### DIFF
--- a/tendenci/apps/base/views.py
+++ b/tendenci/apps/base/views.py
@@ -137,7 +137,7 @@ def image_preview(request, app_label, model, id,  size):
 
 
 def custom_error(request, template_name="500.html"):
-    return render_to_resp(request=request, template_name=template_name)
+    return render_to_resp(request=request, template_name=template_name, status=500)
 
 
 def plugin_static_serve(request, plugin, path, show_indexes=False):


### PR DESCRIPTION
Before this change, an unhandled exception in a view returns a status 200, causing Django error emails never to be sent. Sentry still records the exception regardless. You can trigger such an error by adding `assert False` at the top of any view and looking at the console output.

After this change, an unhandled exception return a status 500 and Django error emails are sent as expected.

Since Tendenci already provides a `templates/500.html`, there's actually no advantage to having `custom_error` at all - Django just looks for 500.html anyway. I suggest removing the `custom_error` function, the `handler500` line in `tendenci/urls.py` and also the `handler500` line `conf/urls.py` in the project template. That change would have to be synchronised between the two repos though.