### PR TITLE
fix: pinning django-countries due to 7.3.0 update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ django-haystack==3.0
 django-debug-toolbar>=3.2.1
 django-sql-explorer==2.1.2
 django-apptemplates>=1.5
+django-countries==7.2.1
 feedparser>=6.0.8
 pytz==2021.3
 simplejson>=3.17.3


### PR DESCRIPTION
A recent update to `django-countries` (version: 7.3.0) breaks the Tendenci installation. Pinning `django-countries` to the previous version resolves this issue (version: 7.2.1).