### PR TITLE
Explicitly specify the encoding when loading theme templates

### DIFF
--- a/tendenci/apps/theme/template_loaders.py
+++ b/tendenci/apps/theme/template_loaders.py
@@ -83,7 +83,7 @@ class ThemeLoader(DjangoLoader):
     def get_contents(self, origin):
         if not origin.use_s3_theme:
             try:
-                with open(origin.name) as fp:
+                with open(origin.name, encoding='utf-8') as fp:
                     return fp.read()
             # Python 3 only
             #except FileNotFoundError:

--- a/tendenci/apps/theme_editor/utils.py
+++ b/tendenci/apps/theme_editor/utils.py
@@ -242,7 +242,7 @@ def get_file_content(root_dir, theme, filename):
     if not content:
         current_file = os.path.join(root_dir, filename)
         if os.path.isfile(current_file):
-            fd = open(current_file, 'r')
+            fd = open(current_file, 'r', encoding='utf-8')
             content = fd.read()
             fd.close()
     return content


### PR DESCRIPTION
After migrating a Tendenci install to a new Ubuntu 22.04 server, I found we were getting errors like "UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 13650: ordinal not in range(128)" (full backtrace included in GitHub comment). This was resolved by adding an explicit encoding to the calls to open.

I wasn't aware, but specifying the `encoding` when opening text files that were not necessarily created in the current locale appears to be a best practice. Details here: https://peps.python.org/pep-0597/ and https://pylint.pycqa.org/en/latest/user_guide/messages/warning/unspecified-encoding.html. I believe that this advice applies here because some theme files may have been created locally, but others may come from upstream.