### PR TITLE
Use TZ datetimes with overrided `date` filter

### DIFF
--- a/tendenci/apps/base/templatetags/base_filters.py
+++ b/tendenci/apps/base/templatetags/base_filters.py
@@ -80,7 +80,7 @@ def date_long(value, arg=None):
             return ''
 date_long.is_safe = False
 
-@register.filter_function
+@register.filter(expects_localtime=True, is_safe=False)
 def date(value, arg=None):
     """Formats a date according to the given format."""
     from django.utils.dateformat import format
@@ -100,7 +100,6 @@ def date(value, arg=None):
             return format(value, arg)
         except AttributeError:
             return ''
-date.is_safe = False
 
 @register.filter_function
 def order_by(queryset, args):


### PR DESCRIPTION
13 years ago, django `date` filter has been overrided in tendency via commit @47e0914e

It was compatible with django date. But 1 year later, django adds support for timezone with the  `date` filter and this change (commit django/django@9b1cb755a28f020e27d4268c214b25315d4de42e) has not been backported in tendenci, resulting all dates displayed in templates with `date` filter are displayed in UTC, whatever the current (user|site) timezone is.