### PR TITLE
use django-admin executable to call commands

### DIFF
--- a/tendenci/apps/articles/views.py
+++ b/tendenci/apps/articles/views.py
@@ -426,7 +426,7 @@ def export(request, template_name="articles/export.html"):
         default_storage.save(temp_file_path, ContentFile(b''))
 
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "articles_export_process",
                           '--identifier=%s' % identifier,
                           '--user=%s' % request.user.id])

--- a/tendenci/apps/base/views.py
+++ b/tendenci/apps/base/views.py
@@ -411,14 +411,14 @@ def addon_upload_preview(request, sid, template_name="base/addon_upload_preview.
     addon_name = addon_zip.namelist()[0]
     addon_name = addon_name.strip('/')
     if not os.path.isdir(os.path.join(settings.SITE_ADDONS_PATH, addon_name)):
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "upload_addon",
                           '--zip_path=%s' % path])
         return redirect('addon.upload.process', sid)
 
     if request.method == "POST":
         shutil.rmtree(os.path.join(settings.SITE_ADDONS_PATH, addon_name))
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "upload_addon",
                           '--zip_path=%s' % path])
         return redirect('addon.upload.process', sid)
@@ -465,7 +465,7 @@ def update_tendenci(request, template_name="base/update.html"):
         tos = request.POST.get('tos')
 
         if tos:
-            subprocess.Popen([python_executable(), "manage.py", "auto_update",
+            subprocess.Popen(["django-admin", "auto_update",
                              "--user_id=%s" % request.user.id])
             return redirect('update_tendenci.confirmation')
 

--- a/tendenci/apps/chapters/models.py
+++ b/tendenci/apps/chapters/models.py
@@ -349,7 +349,7 @@ class CoordinatingAgency(models.Model):
 
     def _populate_group(self):
         if self.group and self.group.members.count() == 0:
-            subprocess.Popen([python_executable(), "manage.py",
+            subprocess.Popen(["django-admin",
                           "sync_chapter_coord_groups",
                           "--coord_agency_id",
                           str(self.pk)])

--- a/tendenci/apps/chapters/views.py
+++ b/tendenci/apps/chapters/views.py
@@ -1370,7 +1370,7 @@ def chapter_memberships_import_preview(request, mimport_id,
                                      args=[mimport.id]))
         else:
             if mimport.status == 'not_started':
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "chapter_membership_import_preprocess",
                               str(mimport.pk)])
 
@@ -1412,7 +1412,7 @@ def chapter_memberships_import_process(request, mimport_id):
         mimport.num_processed = 0
         mimport.save()
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "import_chapter_memberships",
                           str(mimport.pk),
                           str(request.user.pk)])

--- a/tendenci/apps/corporate_memberships/models.py
+++ b/tendenci/apps/corporate_memberships/models.py
@@ -203,7 +203,7 @@ class CorporateMembershipType(OrderingBaseModel, TendenciBaseModel):
         # Sync pending_group and active_group if needed
         if (self.pending_group and self.pending_group != self._original_pending_group) or \
             (self.active_group and self.active_group != self._original_active_group):
-            subprocess.Popen([python_executable(), "manage.py",
+            subprocess.Popen(["django-admin",
                               "sync_corp_reps_groups", '--corp_mem_type_id',
                               str(self.id)])
 

--- a/tendenci/apps/corporate_memberships/views.py
+++ b/tendenci/apps/corporate_memberships/views.py
@@ -148,7 +148,7 @@ def broadcast_email(request):
                     creator=request.user,)
                 bce.save()
                 # start a subprocess to generate a zip file
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "run_broadcast_email",
                               str(bce.pk) ])
                 messages.add_message(request, messages.INFO, _("Your email is being sent. Please reload in a few seconds to check if it's done."))
@@ -1713,7 +1713,7 @@ def import_preview(request, mimport_id,
 #                                 args=[mimport.id]))
         else:
             if mimport.status == 'not_started':
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "corp_membership_import_preprocess",
                               str(mimport.pk)])
 
@@ -1753,7 +1753,7 @@ def import_process(request, mimport_id):
         mimport.num_processed = 0
         mimport.save()
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "import_corp_memberships",
                           str(mimport.pk),
                           str(request.user.pk)])

--- a/tendenci/apps/directories/views.py
+++ b/tendenci/apps/directories/views.py
@@ -670,7 +670,7 @@ def directory_export(request, template_name="directories/export.html"):
         default_storage.save(temp_file_path, ContentFile(b''))
 
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "directory_export_process",
                           '--export_fields=%s' % export_fields,
                           '--export_status_detail=%s' % export_status_detail,

--- a/tendenci/apps/events/views.py
+++ b/tendenci/apps/events/views.py
@@ -4976,7 +4976,7 @@ def reports_financial(request, template_name="events/financial_reports.html"):
             temp_file_path = 'export/events/%s_temp.csv' % identifier
             default_storage.save(temp_file_path, ContentFile(b''))
             # start the process
-            subprocess.Popen([python_executable(), "manage.py",
+            subprocess.Popen(["django-admin",
                               "events_financial_export_process",
                               '--identifier=%s' % identifier,
                               '--start_dt={}'.format(start_dt),

--- a/tendenci/apps/explorer_extensions/views.py
+++ b/tendenci/apps/explorer_extensions/views.py
@@ -37,7 +37,7 @@ def _export_page(request):
                 new_obj.author = request.user
                 new_obj.export_format = form.cleaned_data['format']
                 new_obj.save()
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "create_database_dump",
                               str(request.user.pk), form.cleaned_data['format'], str(new_obj.pk) ])
                 messages.add_message(request, messages.INFO, "Success! The system is now generating your export file. Please reload in a few seconds to update the list.")

--- a/tendenci/apps/invoices/views.py
+++ b/tendenci/apps/invoices/views.py
@@ -823,7 +823,7 @@ def export(request, template_name="invoices/export.html"):
         default_storage.save(temp_file_path, ContentFile(b''))
 
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "invoice_export_process",
                           '--start_dt=%s' % start_dt,
                           '--end_dt=%s' % end_dt,

--- a/tendenci/apps/memberships/utils.py
+++ b/tendenci/apps/memberships/utils.py
@@ -290,7 +290,7 @@ def run_membership_export(request,
     default_storage.save(temp_file_path, ContentFile(b''))
     
     # start the process
-    subprocess.Popen([python_executable(), "manage.py",
+    subprocess.Popen(["django-admin",
                   "membership_export_process",
                   '--export_fields=%s' % export_fields,
                   '--export_type=%s' % export_type,

--- a/tendenci/apps/memberships/views.py
+++ b/tendenci/apps/memberships/views.py
@@ -759,7 +759,7 @@ def membership_default_import_preview(request, mimport_id,
                                      args=[mimport.id]))
         else:
             if mimport.status == 'not_started':
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "membership_import_preprocess",
                               str(mimport.pk)])
 
@@ -783,7 +783,7 @@ def membership_default_import_process(request, mimport_id):
         mimport.num_processed = 0
         mimport.save()
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "import_membership_defaults",
                           str(mimport.pk),
                           str(request.user.pk)])

--- a/tendenci/apps/newsletters/models.py
+++ b/tendenci/apps/newsletters/models.py
@@ -512,7 +512,7 @@ class Newsletter(models.Model):
         return members
 
     def send_to_recipients(self):
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                               "send_newsletter",
                               str(self.pk)])
 

--- a/tendenci/apps/profiles/views.py
+++ b/tendenci/apps/profiles/views.py
@@ -1368,7 +1368,7 @@ def profile_export(request, template_name="profiles/export.html"):
         default_storage.save(temp_file_path, ContentFile(b''))
 
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "profile_export_process",
                           '--export_fields=%s' % export_fields,
                           '--identifier=%s' % identifier,
@@ -1543,7 +1543,7 @@ def user_import_preview(request, uimport_id, template_name='profiles/import/prev
                                      args=[uimport.id]))
         else:
             if uimport.status == 'not_started':
-                subprocess.Popen([python_executable(), "manage.py",
+                subprocess.Popen(["django-admin",
                               "users_import_preprocess",
                               str(uimport.pk)])
 
@@ -1568,7 +1568,7 @@ def user_import_process(request, uimport_id):
         uimport.num_processed = 0
         uimport.save()
         # start the process
-        subprocess.Popen([python_executable(), "manage.py",
+        subprocess.Popen(["django-admin",
                           "import_users",
                           str(uimport.pk),
                           str(request.user.pk)])

--- a/tendenci/apps/reports/views.py
+++ b/tendenci/apps/reports/views.py
@@ -92,7 +92,7 @@ class RunDetailView(DetailView):
         #invalidate('reports_run')
         obj = get_object_or_404(Run, pk=self.kwargs['pk'], report_id=self.kwargs['report_id'])
         if obj.status == "unstarted":
-            subprocess.Popen([python_executable(), "manage.py", "process_report_run", str(obj.pk)])
+            subprocess.Popen(["django-admin", "process_report_run", str(obj.pk)])
         return obj
 
 

--- a/tendenci/apps/theme_editor/views.py
+++ b/tendenci/apps/theme_editor/views.py
@@ -597,7 +597,7 @@ def get_themes(request, template_name="theme_editor/get_themes.html"):
         return HttpResponse(tracker.is_updating)
 
     if request.method == 'POST':
-        subprocess.Popen([python_executable(), "manage.py", "install_theme", "--all"])
+        subprocess.Popen(["django-admin", "install_theme", "--all"])
         return render_to_resp(request=request, template_name=template_name)
 
     raise Http404

--- a/tendenci/apps/trainings/admin.py
+++ b/tendenci/apps/trainings/admin.py
@@ -435,7 +435,7 @@ class BluevoltExamImportAdmin(admin.ModelAdmin):
             obj.run_by = request.user
             obj.save()
             
-            subprocess.Popen([python_executable(), "manage.py",
+            subprocess.Popen(["django-admin",
                               "import_bluevolt_exams",
                               "--import_id",
                               str(obj.id)])  

--- a/tendenci/apps/trainings/views.py
+++ b/tendenci/apps/trainings/views.py
@@ -277,7 +277,7 @@ def transcripts(request, user_id=None, corp_profile_id=None,
                 creator=request.user,)
             ctzf.save()
             # start a subprocess to generate a zip file
-            subprocess.Popen([python_executable(), "manage.py",
+            subprocess.Popen(["django-admin",
                               "generate_transcript_pdfs",
                               str(ctzf.pk) ])
             # redirect to the status page

--- a/tendenci/apps/user_groups/views.py
+++ b/tendenci/apps/user_groups/views.py
@@ -574,7 +574,7 @@ def group_members_export(request, group_slug, export_target='all'):
                                             identifier)
     default_storage.save(temp_export_path, ContentFile(b''))
     # start the process
-    subprocess.Popen([python_executable(), "manage.py",
+    subprocess.Popen(["django-admin",
                   "group_members_export",
                   '--group_id=%d' % group.id,
                   '--export_target=%s' % export_target,


### PR DESCRIPTION
`subprocess.Popen([python_executable(), "manage.py", ...]` wont work if manage.py is not directly in the path of the subprocess.

Plus the use of django-admin remove the need of a complex python executable selector