### PR TITLE
Fix: Invoice 'Download PDF' asks to sign-in

### DIFF
--- a/tendenci/themes/t7-base/templates/invoices/view.html
+++ b/tendenci/themes/t7-base/templates/invoices/view.html
@@ -82,12 +82,14 @@
     </ul>
   </div>
   {% if not invoice.is_void %}
-  
+
+  {% if request.user.is_superuser or can_edit %}
   <div class="invoice-options">
     <ul>
       <li><a href="{% url "invoice.download" invoice.id %}">{% trans 'Download PDF' %}</a></li>
     </ul>
   </div>
+  {% endif %}
 
  {% if request.user.is_superuser %}
   <div class="invoice-options">


### PR DESCRIPTION
When not signed-in, the invoice button `Download PDF` asks to sign-in, which is confusing. If this operation isn't available for a anonymous person, I propose to hide it.