### PR TITLE
Include all dates on certificate

### DIFF
--- a/tendenci/apps/events/views.py
+++ b/tendenci/apps/events/views.py
@@ -4091,7 +4091,7 @@ def sample_certificate(request, event_id=0, template_name='events/registrants/ce
         'license_number': 123456789,
         'license_state': 'TX',
         'ptin': 987654321,
-        'event_dates_display': datetime.now().date().strftime('%b %d, %Y'),
+        'event_dates_display': event.event_dates_display,
         'possible_cpe_credits': event.possible_cpe_credits,
         'credits_earned': event.possible_cpe_credits,
         'irs_credits_earned': 5.0,

--- a/tendenci/themes/t7-base/templates/events/registrants/certificate-single-event.html
+++ b/tendenci/themes/t7-base/templates/events/registrants/certificate-single-event.html
@@ -205,7 +205,7 @@
             {% endif %}
             <div class="row">
               <div class="left">{% trans "Date:" %}</div>
-              <div class="right"> {{ registrant.event_dates_display }}</div>
+              <div class="right"> {{ registrant.event.start_dt|date:"F j, Y" }}</div>
             </div>
             <div class="row">
               <div class="left">{% trans "Location: "%}</div>

--- a/tendenci/themes/t7-base/templates/events/registrants/certificate-symposium.html
+++ b/tendenci/themes/t7-base/templates/events/registrants/certificate-symposium.html
@@ -63,7 +63,8 @@
   }
   
   .certificate .row.staff {
-      margin-bottom: 70px;
+      margin-bottom: 50px;
+      height: 50px;
       margin-top: 30px;
       display: flex;
       align-items: center;


### PR DESCRIPTION
Per Nicole: "Confirmed symposium cert dates are event dates, not just dates attended"

Updated to include all dates in events (not just the ones the registrant attended)
Since it is no longer registrant specific, was able to switch out the sample cert with all dates of event instead of current date as well.