### PR TITLE
15.1 blank screen forums 403 HttpResponseForbidden should re-raise

### DIFF
--- a/tendenci/apps/forums/views.py
+++ b/tendenci/apps/forums/views.py
@@ -59,7 +59,7 @@ class RedirectToLoginMixin(object):
                 from django.contrib.auth.views import redirect_to_login
                 return redirect_to_login(self.get_login_redirect_url())
             else:
-                return HttpResponseForbidden()
+                raise
 
     def get_login_redirect_url(self):
         """ get the url to which we redirect after the user logs in. subclasses should override this """


### PR DESCRIPTION
when an authenticated user gets permission denied in tendenci/apps/forums/views.py, a blank page is returned because HttpResponseForbidden is called with no text. Replace return HttpResponseForbidden() in the RedirectToLoginMixin function with raise
to reraise the PermissionDenied exception works perfect.

It looks like this with the reraised exception. Fred (not a member) is trying to see a forum that needs a membership. Fred sees the correct message, not a blank screen.
![403](https://github.com/tendenci/tendenci/assets/71161286/d3d3c440-b4da-4d64-aa8f-f6d12b8f9150)
