### PR TITLE
Minor check-in updates

### DIFF
--- a/tendenci/apps/events/forms.py
+++ b/tendenci/apps/events/forms.py
@@ -2061,7 +2061,8 @@ class FreePassCheckForm(forms.Form):
 
 class EventTitleChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return f"{obj.short_name} {obj.start_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')} - {obj.end_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')}"
+        event_name = obj.short_name if obj.short_name else obj.title
+        return f"{event_name} {obj.start_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')} - {obj.end_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')}"
     
 
 class EventCheckInForm(forms.Form):

--- a/tendenci/apps/events/forms.py
+++ b/tendenci/apps/events/forms.py
@@ -2061,7 +2061,7 @@ class FreePassCheckForm(forms.Form):
 
 class EventTitleChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return f"{obj.title} {obj.start_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')} - {obj.end_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')}"
+        return f"{obj.short_name} {obj.start_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')} - {obj.end_dt.strftime('%I:%M %p').lstrip('0').replace(':00', '')}"
     
 
 class EventCheckInForm(forms.Form):

--- a/tendenci/apps/events/views.py
+++ b/tendenci/apps/events/views.py
@@ -4325,11 +4325,6 @@ def digital_check_in(request, registrant_id, template_name='events/reg8n/checkin
     error_message = None
     event = registrant.registration.event
 
-    # Determine if sub event check in should be attempted. This must be 
-    # done before checking in to the main event since it depends on current 
-    # check in status.
-    should_check_in_to_sub_event = registrant.should_check_in_to_sub_event
-
     # If not yet checked into parent event, check in.
     # This also applies to single meeting events.
     check_in = not error_message and not registrant.checked_in
@@ -4354,7 +4349,7 @@ def digital_check_in(request, registrant_id, template_name='events/reg8n/checkin
 
     confirm_session_check_in = False
     form = None
-    if should_check_in_to_sub_event:
+    if registrant.should_check_in_to_sub_event:
         # Try to get check in for registrant. 
         # Check in registrant if successful (display error if fails)
         child_event, error_level, error_message = registrant.try_get_check_in_event(request)


### PR DESCRIPTION
Minor check-in updates:

- Use short name on drop-down for check-in session selection so it fits better on smaller screens
-  Don't require initial scan to the main event. Instead automatically check registrants in to main event when scanning into a session.