### PR TITLE
Update 403 and 404 pages to include error codes

### DIFF
--- a/tendenci/themes/t7-base/templates/403.html
+++ b/tendenci/themes/t7-base/templates/403.html
@@ -7,6 +7,8 @@
   {{ MODULE_USERS_USERSSECURITYMESSAGE }}
 {% else %}
 {% if user.is_authenticated %}
+<h1>403</h1>
+<h2>{% trans "Access Denied" %}</h2>
 <p>{% trans "You can't go to this page right now because you do not have the correct access rights." %}</p>
 <p>{% trans "Please contact the site administrator to request access to this page." %}</p>
 {% else %}

--- a/tendenci/themes/t7-base/templates/404.html
+++ b/tendenci/themes/t7-base/templates/404.html
@@ -5,7 +5,8 @@
 {% block banner %}{% endblock %}
 
 {% block content %}
-    <h1>{% trans "The page was not found" %}</h1>
+    <h1>404</h1>
+    <h2>{% trans "The page was not found" %}</h2>
     <p>{% trans "Possible reasons" %}</p>
     <ul>
         <li>{% blocktrans with request.get_full_path as reqpath %}The page moved from <code>{{ reqpath }}</code> to another path like <code>/cool-stuff/</code>.{% endblocktrans %}</li>


### PR DESCRIPTION
We've had some very vague requests from members when there is a 403, so this is an update to 403.html and 404.html to include the error codes '403' and '404' to make our lives easier when diagnosing! 