### PR TITLE
Remove <br> from help-files index.html to fix topics formatting

### DIFF
--- a/tendenci/themes/t7-base/templates/help_files/index.html
+++ b/tendenci/themes/t7-base/templates/help_files/index.html
@@ -83,7 +83,6 @@
           <ul class="list-group">
             {% for topic in topics.1 %}
             <li class="list-group-item"><a href="{% url "help_files.topic" topic.pk %}">{{ topic }}</a></li>
-            <br>
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
I don't know the full history of this html, but for the purpose of remove extra spaces from the list of topics, this seemed to fix the issue.