### PR TITLE
Update directory expiration date after directory edit

### DIFF
--- a/tendenci/apps/directories/views.py
+++ b/tendenci/apps/directories/views.py
@@ -316,7 +316,11 @@ def edit(request, id, form_class=DirectoryForm, template_name="directories/edit.
                     #directory.logo = None
             
             # set the expiration date in case activation date and/or requested_duration have changed
-            directory.expiration_dt = directory.activation_dt + timedelta(days=directory.requested_duration)
+            if directory.activation_dt and directory.requested_duration:
+                directory.expiration_dt = directory.activation_dt + timedelta(days=directory.requested_duration)
+            else:
+                # If activation date or requested duration are empty, expiration date should also be empty
+                directory.expiration_dt = None
 
             # update all permissions and save the model
             directory = update_perms_and_save(request, form, directory)

--- a/tendenci/apps/directories/views.py
+++ b/tendenci/apps/directories/views.py
@@ -314,6 +314,10 @@ def edit(request, id, form_class=DirectoryForm, template_name="directories/edit.
                 except IOError:
                     pass
                     #directory.logo = None
+            
+            # set the expiration date in case activation date and/or requested_duration have changed
+            directory.expiration_dt = directory.activation_dt + timedelta(days=directory.requested_duration)
+
             # update all permissions and save the model
             directory = update_perms_and_save(request, form, directory)
             form.save_m2m()


### PR DESCRIPTION
Update directory.expiration_dt after editing a directory to realign to any changes to start date or duration

This addresses issue #1311 