### PR TITLE
USER_IS_STAFF for reports seems more reasonable than USER_IS_SUPERUSER

### DIFF
--- a/tendenci/themes/t7-base/templates/top_menu/admin_top-new.html
+++ b/tendenci/themes/t7-base/templates/top_menu/admin_top-new.html
@@ -25,7 +25,7 @@
 
                 {% include 'top_menu/_apps_dropdown.html' %}
 
-                {% if USER_IS_SUPERUSER %}
+                {% if USER_IS_STAFF %}
                 {% include 'top_menu/_reports_dropdown.html' %}
                 {% endif %}
 


### PR DESCRIPTION
In the ideal, this would be configurable. But too many things in tendenci are only available to website admins (super users) and association reports clearly should be available to committee members and/or staff etc. At least, in any Association I've worked it. They don't all need or want to be website super users/admins.