### PR TITLE
Exploring fix for #1325

### DIFF
--- a/tendenci/apps/site_settings/utils.py
+++ b/tendenci/apps/site_settings/utils.py
@@ -97,11 +97,9 @@ def get_setting(scope, scope_category, name):
                 'name': name
             }
             
-            if not apps.ready and not apps.stored_app_configs:
+            if not apps.ready and not apps.stored_app_configs and 'site_settings' in list(apps.app_configs.keys()):
                 # If a RuntimeWarning of APPS_NOT_READY_WARNING_MSG would be issued, 
-                # suppress that warning for this settings request. Premises that the 
-                # settings model is read and Settings.objects can deliver. Can we 
-                # test/confirm that? 
+                # suppress that warning for this settings request.  
                 stored_app_configs = apps.stored_app_configs
                 apps.stored_app_configs = True
                 setting = Setting.objects.get(**filters)


### PR DESCRIPTION
A quick experiment to suppress the copious RuntimeWarning messages tendenci generates, as described in: https://github.com/tendenci/tendenci/issues/1325

This works, but it has some subtle premises of course in terms of how to determine if a given app config is available during initialisation. 

Essentially, two model queries have been optionally wrapped around a little suppression code. It is not 100% risk-free, as it sets django.apps.apps.stored_app_configs to an illegal but functional value for suppression for the duration of the call. It's wrapped tightly around the evaluation of queryset in both instances and works, but given the queryset evaluation is a call into Django it's not impossible that Django at some point, in some circumstances, presumes this to be a list (its falsey value is `[]`). We could of course set it to a list like `[true]` but that just pushes the risk downstream a little, as we can't add a valid config to the list for lack of one yet. 

Also, this premises that Tendenci wants to do this. The better approach, more canonical and recommended, would be to make these evaluations lazy and procrastinate them unto apps.ready is true! But that will take a little more thinking and design than I've invested to date. 

This PR is proof at least that there are only two pinch points.