### PR TITLE
disable_template_cache was crashing.

### DIFF
--- a/tendenci/settings.py
+++ b/tendenci/settings.py
@@ -149,7 +149,9 @@ TEMPLATES = [
   }
 ]
 def disable_template_cache():  # For use in site-specific settings.py
-    TEMPLATES[0]['OPTIONS']['loaders'] = TEMPLATES[0]['OPTIONS']['loaders'][0][1]
+    if TEMPLATES[0]['OPTIONS']['loaders'][0][0] == 'tendenci.apps.theme.template_loaders.CachedLoader':
+        TEMPLATES[0]['OPTIONS']['loaders'] = TEMPLATES[0]['OPTIONS']['loaders'][0][1]
+        
 # The form renderer does not use the TEMPLATES setting by default.  Configure it to use the
 # TEMPLATES setting so that form widget templates can be overridden in themes.
 # This requires either adding 'django.forms' to INSTALLED_APPS or adding


### PR DESCRIPTION
Turns out if settings are loaded more than once this one liner breaks down fast. Added a check that we're actually disabling the cached loader which is more robust and clearer to the reader as well.