### PR TITLE
Set button label to "Join Webinar" if the Zoom event is a webinar and not a regular meeting

### DIFF
--- a/tendenci/themes/t7-base/templates/events/view.html
+++ b/tendenci/themes/t7-base/templates/events/view.html
@@ -129,7 +129,12 @@ div.small-font {
 			      {% endif %}
             {% if registrant_user and event.enable_zoom_meeting %}
             <div class="btn btn-success">
-              <a href="{% url 'event.zoom' event.pk %}" style="color:white;">{% trans "Join Meeting" %}</a>
+	       <a href="{% url 'event.zoom' event.pk %}" style="color:white;">
+		    {% if event.place.is_zoom_webinar %}
+		      {% trans "Join Webinar" %}
+		    {% else %}
+	       	      {% trans "Join Meeting" %}
+		</a>
             </div>
             {% else %}
             <div class="small-font">


### PR DESCRIPTION
Fixes #1348.