### PR TITLE
Adress cache issues found in #1109

### DIFF
--- a/tendenci/apps/rss/feeds.py
+++ b/tendenci/apps/rss/feeds.py
@@ -18,21 +18,48 @@ max_items = settings.MAX_RSS_ITEMS
 if not max_items: max_items = 100
 
 
-class GlobalFeed(Feed):
-    title =  _('%(dname)s RSS Feed' % {'dname':site_display_name})
-    link = '%s/rss' % (site_url)
+class RSSFeed(Feed):
     description = site_description
 
     def __init__(self):
-        super(GlobalFeed, self).__init__()
+        super().__init__()
         self.__qualname__ = self.__class__.__name__  # https://code.djangoproject.com/ticket/29296
         self.all_items = []     # all items for this rss feed
+        self.app_items = {}     # app items for this rss feed
         self.feed_for_item = {}   # item -> feed cache
+
+    def get_feed(self, obj, request):
+        """
+        Django Syndication does not pass URL parameters into get_feed.
+        Feed.__call__ receives them in kwargs but does not pass them to
+        get_feed alas. Fixes for this include:
+            1. Fixing Django to pass args and kwargs into get_feed (long lead time)
+            2. Overriding __call__ here to fix that (not appealing as __call__ does a few things)
+            3. Overriding get_feed and sucking them out of DJango's request.
+
+        This implements 3, judged to be the fastest, simplest solution for now. A Django fix is ideal too.
+        """
+        self.app = request.resolver_match.kwargs.get('app', None)
+
+        if self.app:
+            self.title =  _(f'{site_display_name}s {self.app.title()} RSS Feed')
+            self.link = f'{site_url}/{self.app}/rss'
+        else:
+            self.title =  _(f'{site_display_name}s RSS Feed')
+            self.link = f'{site_url}/rss'
+
+        return super().get_feed(obj, request)
 
     def load_feeds_items(self):
         """ Load all feeds items """
         #print("creating new feeds_items")
-        feeds = feedsmanager.get_all_feeds()
+        if self.app:
+            feeds = [feedsmanager.get_app_feed(self.app)]
+            if not self.app in self.app_items:
+                self.app_items[self.app] = []
+        else:
+            feeds = feedsmanager.get_all_feeds()
+
         for feed in feeds:
             feed_instance = feed()
             #print("Feed found: %s" % feed_instance.title)
@@ -40,19 +67,26 @@ class GlobalFeed(Feed):
             for item in feed_instance.items():
                 #print("Item: %s" % feed_instance.item_title(item))
                 self.feed_for_item[item] = feed_instance
+
                 self.all_items.append(item)
+                if self.app:
+                    self.app_items[self.app].append(item)
+
                 item_per_feed_cnt += 1
                 if item_per_feed_cnt >= settings.MAX_FEED_ITEMS_PER_APP:
                     break
 
     def items(self):
-        if not self.all_items:
+        if ( (not self.app and not self.all_items)
+          or (self.app and not self.app in self.app_items)
+          or getattr(settings, 'DISABLE_RSS_CACHE', False)):
             # This method is moved from '__init__' to here to avoid querying db thus
             # avoid the error "column doesn't exist" on system checks when making new
             # migrations with the 'makemigrations' command and also applying the migrations
             # with  the 'migrate' commands.
             self.load_feeds_items() # load items
-        return self.all_items[:max_items]
+
+        return self.app_items[self.app][:max_items] if self.app else self.all_items[:max_items]
 
     @strip_control_chars
     def item_title(self, item):

--- a/tendenci/apps/rss/feedsmanager.py
+++ b/tendenci/apps/rss/feedsmanager.py
@@ -1,3 +1,5 @@
+import importlib
+
 from datetime import datetime
 
 from django.contrib.syndication.views import Feed
@@ -36,10 +38,16 @@ def get_all_feeds():
         _try_import(app + '.feeds')
     return SubFeed.__subclasses__()
 
-
 def _try_import(module):
     try:
         __import__(module)
     except ImportError:
         pass
         #print("Failed to import feeds file: %s" % e)
+
+def get_app_feed(app):
+    try:
+        return importlib.import_module(f'tendenci.apps.{app}.feeds').LatestEntriesFeed
+    except ImportError:
+        return None
+

--- a/tendenci/apps/rss/urls.py
+++ b/tendenci/apps/rss/urls.py
@@ -1,7 +1,9 @@
 from django.urls import re_path
 #from . import views
-from .feeds import GlobalFeed
+from .feeds import RSSFeed
+
+app_name = 'rss'
 
 urlpatterns = [
-    re_path(r'^$', GlobalFeed(), name="rss.mainrssfeed"),
+    re_path(r'^$', RSSFeed(), name="rss.mainrssfeed")
 ]

--- a/tendenci/urls.py
+++ b/tendenci/urls.py
@@ -59,7 +59,7 @@ urlpatterns += [
     re_path(r'^rp/', include('tendenci.apps.recurring_payments.urls')),
     re_path(r'^accountings/', include('tendenci.apps.accountings.urls')),
     re_path(r'^emails/', include('tendenci.apps.emails.urls')),
-    re_path(r'^rss/', include('tendenci.apps.rss.urls')),
+    re_path(r'^((?P<app>\w+)/)?rss/', include('tendenci.apps.rss.urls')),
     re_path(r'^imports/', include('tendenci.apps.imports.urls')),
     #re_path(r'^donations/', include('donations.urls')),
     re_path(r'^settings/', include('tendenci.apps.site_settings.urls')),


### PR DESCRIPTION
Addresses https://github.com/tendenci/tendenci/issues/1109

Migrated from https://github.com/tendenci/tendenci/pull/1110

because it is a squash rebase on main in an admin tidy up and github fails to reflect pushes to the branch in the PR based on the branch. It used to (something has changed)

The conversation was not finished there:

jennyq wrote:
> Great job on identifying the issue!
> 
> For the app specific RSS feeds, they are there already. For example, you can access news feed at /news/feed/. And those are not cached.
> 
> For the global RSS feed, it definitely shouldn't be saved in the `self.all_items` all the time, but it can be heavy if it needs to load every time. The update you've made introduced the `DISABLE_RSS_CACHE` setting, but still saved in `self.all_items` if the setting is False. I think a possible better solution is - they can be put in cache with a setting to adjust the cache timeout. And they can also give the option to manually reload the feed if needed. Thoughts?

No head space to think about this now, just some admin tidy ups for now. We should decide on a way forward here indeed.