### PR TITLE
A better layout for committee pages

### DIFF
--- a/tendenci/themes/t7-base/templates/committees/detail.html
+++ b/tendenci/themes/t7-base/templates/committees/detail.html
@@ -18,14 +18,8 @@
       {{ committee.mission|safe }}
     </div>
     
-    <div class="committee-content">
-      {{ committee.content|safe }}
-    </div>
-    
     <div class="committee-officers">
-      <div class="label">
-        <label for="officer-table">OFFICERS</label>
-      </div>
+      <h2>Members</h2>
       <table class="table" id="officer-table">
         <thead>
           <tr>
@@ -48,13 +42,12 @@
             <td class="officer-name">
               <a href="{% url 'profile' officer.user.username  %}">
                 {% if officer.user.get_full_name %}
-                {{ officer.user.get_full_name }}
+	                {{ officer.user.get_full_name }}
                 {% else %}
-                {{ officer.user }}
+    	            {{ officer.user }}
                 {% endif %}
               </a>
             </td>
-
             {% if show_officers_phone %}
             <td class="officer-phone">{% if officer.phone %}{{ officer.phone }}{% endif %}</td>
             {% endif %}
@@ -65,6 +58,10 @@
           {% endfor %}
         </tbody>
       </table>
+    </div>
+    
+    <div class="committee-content">
+      {{ committee.content|safe }}
     </div>
     
     <div class="committee-sponsors">
@@ -78,9 +75,11 @@
     {% endif %}
     
     <div class="committee-files">
-      <h2>Files {% if admin %}</h2>
+      <h2>Files</h2>
       
-      <a class="btn btn-default" href="{% url "file.add" %}">Add a File</a>{% endif %}
+      {% if admin %}
+      <a class="btn btn-default" href="{% url "file.add" %}">Add a File</a>
+      {% endif %}
       
       <ul class="file-list">
         {% for file in files %}


### PR DESCRIPTION
Migrated from https://github.com/tendenci/tendenci/pull/967 because github is not updating the PR after a rebase,s quash and tidy up. This is a WIP with notes in the parent PR that need resolution. 

Subjective but I put the committee members after mission before content, and I removed the hone columns (who is publishing a committees phone numbers by default today? Easy to add, to a local template but the default should most certainly not assume phone number exposure.