### PR TITLE
Made the Members Quick List much more useful

### DIFF
--- a/tendenci/apps/base/templatetags/base_filters.py
+++ b/tendenci/apps/base/templatetags/base_filters.py
@@ -9,6 +9,8 @@ from dateutil.parser import parse
 from datetime import datetime, time
 
 from decimal import Decimal
+from urllib.parse import urlencode
+
 from django.template import Library
 from django.conf import settings
 from django.template.defaultfilters import stringfilter
@@ -526,3 +528,14 @@ def url_complete(value):
 def zip_lists(a, b):
     """zip lists together"""
     return zip(a, b)
+
+@register.filter
+def with_parameters(request, parameter):
+    """ Given a request returns the path of that request with the provided GET paramters added or substituting existing ones."""
+    d = dict(request.GET.items())
+    for param in parameter.split('&'):
+        key, value = param.split('=', 1)
+        d[key] = value
+
+    return f"{request.path}?{urlencode(d)}"
+

--- a/tendenci/apps/base/templatetags/base_tags.py
+++ b/tendenci/apps/base/templatetags/base_tags.py
@@ -1,5 +1,6 @@
 import re
 from urllib.request import urlopen
+from urllib.parse import urlencode
 from hashlib import md5
 
 from tagging.templatetags.tagging_tags import TagsForObjectNode
@@ -856,7 +857,6 @@ def all_tags_list():
     tag_list = ",".join(['"%s"' % t.name for t in tags])
     return mark_safe(tag_list)
 
-
 @register.simple_tag
 def execute_method(obj, method_name, *args):
     """
@@ -865,3 +865,17 @@ def execute_method(obj, method_name, *args):
     """
     method = getattr(obj, method_name)
     return method(*args)
+
+@register.simple_tag()
+def order_by(request, current, field):
+    d = dict(request.GET.items())
+    
+    if field == current:
+        if current.startswith('-'):
+            field = field[1:]
+        else:
+            field = '-' + field
+            
+    d['order_by'] = field 
+    return f"{request.path}?{urlencode(d)}"
+

--- a/tendenci/apps/exports/utils.py
+++ b/tendenci/apps/exports/utils.py
@@ -56,6 +56,11 @@ def render_csv(filename, title_list, data_list):
                     row_item_list[i] = row_item_list[i].strftime('%Y-%m-%d')
                 elif isinstance(row_item_list[i], datetime.time):
                     row_item_list[i] = row_item_list[i].strftime('%H:%M:%S')
+                elif isinstance(row_item_list[i], list):
+                    row_item_list[i] = ', '.join(row_item_list[i])
+            elif isinstance(row_item_list[i], list):
+                row_item_list[i] = ""
+                
         csv_writer.writerow(row_item_list)
 
     return response

--- a/tendenci/themes/t7-base/static/css/reports.css
+++ b/tendenci/themes/t7-base/static/css/reports.css
@@ -115,6 +115,13 @@ tr.odd {
   font-weight: bold;
   vertical-align: middle;
 }
+
+/* Header links for sorting columns should be subtle not distracting */
+.table th a {
+  color: inherit; 		               
+  text-decoration: inherit !important; 
+}
+
 .table td {
   vertical-align: top;
   border-top: 1px solid #ddd;

--- a/tendenci/themes/t7-base/templates/reports/membership_quick_list.html
+++ b/tendenci/themes/t7-base/templates/reports/membership_quick_list.html
@@ -1,6 +1,7 @@
 {% extends "reports/base.html" %}
 {% load membership_tags %}
 {% load bootstrap_pagination_tags %}
+{% load base_tags %}
 
 {% block content %}
 <div class="page-header">
@@ -23,17 +24,41 @@
     {% search_region_form %}
     </p>
 {% if members %}
+<p><a class="btn btn-primary" href="{% url "reports-members-quick-list" %}?output=csv">
+    {% trans 'Download CSV File' %}</a></p>
+    <p>{{ members | length }} active members</p>
+
     <table class="table table-tendenci-reports">
         <tr>
-            <th>{% trans "Last Name" %}</th>
-            <th>{% trans "First Name" %}</th>
-            <th>{% trans "Company" %}</th>
+            <th><a href="{% order_by request order_by 'member_number_int' %}">{% trans "Member Number" %}</a></th>
+            <th><a href="{% order_by request order_by 'membership_type' %}">{% trans "Membership Type" %}</a></th>
+            <th><a href="{% order_by request order_by 'user__last_name' %}">{% trans "Last Name" %}</a></th>
+            <th><a href="{% order_by request order_by 'user__first_name' %}">{% trans "First Name" %}</a></th>
+            <th><a href="{% order_by request order_by 'user__profile__company' %}">{% trans "Company" %}</a></th>
+            <th>{% if members.first.user_group_list %}
+            		<a href="{% order_by request order_by 'user_group_list' %}">
+	            {% endif %}
+	            {% trans "Groups" %}
+	            {% if member.user_group_list %}
+	            	</a>
+	            {% endif %}
+	         </th>
         </tr>
         {% for member in members %}
         <tr>
+            <td>{{ member.member_number }}</td>
+            <td>{{ member.membership_type }}</td>
             <td>{{ member.user.last_name }}</td>
             <td>{{ member.user.first_name }}</td>
             <td>{{ member.user.profile.company }}</td>
+            <td>{% if member.user_group_list %}
+	            	{{ member.user_group_list }}
+	            {% else %}
+					{% for group in member.user.user_groups.all %}
+					    {{ group.name }} {% if not forloop.last %}, {% endif %} 
+					{% endfor %}
+	            {% endif %}
+			</td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
Rebased on main, squashed, and tidied. This replaces https://github.com/tendenci/tendenci/pull/945/files which should have been automatically updated in the PR when this branch was pushed. But alas not. So only option close and reopen.

TODO: There is feedback in the original PR to appraise and act on.

Added important columns: Member number, Membership Type and Groups. Added click-able headers that sort the table
TODO: The group header is not click-able. Against all documentation for some reason I cannot convince this version of Django (and it could be because it's old) to understand "user__group_set" which works a charm ion the template, but annotate and order_by both barf at it complaining that group_set can't be found as a field dumping a list of available fields (from which it is conspicuously missing indeed) Fixed the confusion about user_groups
Turns out group_set didn't work, probably because of an ambiguity, namely the Group model has three whole foreign references to User and none hd related_names. So added a related_name for the user_groups and suddenly everything worked. Implemented reversible sorting.
Could not find a way to do that with a generic user_group list, so only in the postgresql case is the user_group column orderable. Fixed unused imports
Fixed a bug in the header link test
And ordered group list by id