### PR TITLE
 Convert span elements with datetime attributes to time elements

### DIFF
--- a/tendenci/themes/t7-base/templates/events/day-view.html
+++ b/tendenci/themes/t7-base/templates/events/day-view.html
@@ -64,7 +64,7 @@
                 <div class="time-stamp">
                   {% if not event.all_day %}{{ event.start_dt|date:"f A" }} - {{ event.end_dt|date:"f A" }}{% endif %}
                 </div>
-                <span style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</span>
+                <time style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</time>
             {% if event.start_dt|date:"D, M. j, Y" != event.end_dt|date:"D, M. j, Y" %}
                 <div class="ongoing-event">{% trans 'Multi-day Event' %}</div>
             {% endif %}

--- a/tendenci/themes/t7-base/templates/events/month-view.html
+++ b/tendenci/themes/t7-base/templates/events/month-view.html
@@ -134,7 +134,7 @@
                 <a href="{{ event.get_absolute_url }}" class="time-stamp">
                   {% if not event.all_day %}{{ event.start_dt|date:"f A" }} - {{ event.end_dt|date:"f A" }}<br/>{% endif %}
                 </a>
-                <span style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</span>
+                <time style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</time>
                 <a href="{{ event.get_absolute_url }}" class="event-title" itemprop="url">
                   <span itemprop="name">{{ event.title|truncatechars:15 }}</span>
                 </a>

--- a/tendenci/themes/t7-base/templates/events/search-result.html
+++ b/tendenci/themes/t7-base/templates/events/search-result.html
@@ -61,11 +61,11 @@
 
         <div class="time-period">
             {% if event.all_day %}
-            <span itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y" }}</span> -
-            <span itemprop="endDate" datetime="{{ event.end_dt|date:'c' }}">{{ event.end_dt|date:"l, M j, Y" }}</span>
+            <time itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y" }}</time> -
+            <time itemprop="endDate" datetime="{{ event.end_dt|date:'c' }}">{{ event.end_dt|date:"l, M j, Y" }}</time>
             {% else %}
-             <span itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</span> -
-             <span itemprop="endDate" datetime="{{ event.end_dt|date:'c' }}">{{ event.end_dt|date:"l, M j, Y P" }}</span>
+             <time itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</time> -
+             <time itemprop="endDate" datetime="{{ event.end_dt|date:'c' }}">{{ event.end_dt|date:"l, M j, Y P" }}</time>
             {% endif %}
         </div>
 

--- a/tendenci/themes/t7-base/templates/events/view.html
+++ b/tendenci/themes/t7-base/templates/events/view.html
@@ -92,11 +92,11 @@ div.small-font {
           <h3>
             {% for span in event.date_spans %}
             {% if span.same_date %}
-            <span itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"N j, Y" }}</span>
+            <time itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"N j, Y" }}</time>
             {% if not forloop.last %} and {% endif %}
             {% else %}
-            <span itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"M. j" }}</span> -
-            <span itemprop="endDate" datetime="{{ span.end_dt|date:'c' }}">{{ span.end_dt|date:"M. j, Y" }}</span>
+            <time itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"M. j" }}</time> -
+            <time itemprop="endDate" datetime="{{ span.end_dt|date:'c' }}">{{ span.end_dt|date:"M. j, Y" }}</time>
             {% endif %}
             {% endfor %}
           </h3>
@@ -321,12 +321,12 @@ div.small-font {
         
         {% for span in event.date_spans %}
         {% if span.same_date %}
-        <p><span itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"D, N j, Y" }}</span></p>
+        <p><time itemprop="startDate" datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"D, N j, Y" }}</time></p>
         
         {% if not forloop.last %} and {% endif %}
         {% else %}
-        <p><span datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"D, M. j" }}</span></p> -
-        <p><span datetime="{{ span.end_dt|date:'c' }}">{{ span.end_dt|date:"D, M. j, Y" }}</span></p>
+        <p><time datetime="{{ span.start_dt|date:'c' }}">{{ span.start_dt|date:"D, M. j" }}</time></p> -
+        <p><time datetime="{{ span.end_dt|date:'c' }}">{{ span.end_dt|date:"D, M. j, Y" }}</time></p>
         {% if not forloop.last %} and {% endif %}
         {% endif %}
         

--- a/tendenci/themes/t7-base/templates/events/week-view.html
+++ b/tendenci/themes/t7-base/templates/events/week-view.html
@@ -65,7 +65,7 @@
                 <a href="{{ event.get_absolute_url }}" class="time-stamp">
                   {% if not event.all_day %}{{ event.start_dt|date:"f A" }} - {{ event.end_dt|date:"f A" }}<br/>{% endif %}
                 </a>
-                <span style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</span>
+                <time style="display:none" itemprop="startDate" datetime="{{ event.start_dt|date:'c' }}">{{ event.start_dt|date:"l, M j, Y P" }}</time>
                 <a href="{{ event.get_absolute_url }}" class="event-title" itemprop="url">
                   <span itemprop="name">{{ event.title }}</span>
                 </a>


### PR DESCRIPTION
datetime is an attribute of time - https://www.w3schools.com/Tags/tag_time.asp

This is resulting in "Date/time not in ISO 8601 format in field 'startDate'" from google's use of the event markup.