### PR TITLE
Bump xhtml2pdf to 0.2.17 to fix ReDOS vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ bleach>=6.1.0
 django-bootstrap-form>=3.1,<4
 email-reply-parser
 django-markdown-deux
-xhtml2pdf==0.2.16
+xhtml2pdf==0.2.17
 reportlab==4.2.2
 python-magic
 nameparser


### PR DESCRIPTION
Fix for #1380 
Eliminate potential ReDOS vulnerability - see https://xhtml2pdf.readthedocs.io/en/latest/release-notes.html#id1