### PR TITLE
Quality: Deprecated simplejson Usage

### DIFF
--- a/tendenci/apps/api/views.py
+++ b/tendenci/apps/api/views.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-import simplejson
+import json
 from django.views.decorators.csrf import csrf_exempt
 from .utils import validate_api_request
 
@@ -34,8 +34,8 @@ def api_rp(request):
     #result_code_error = {'result_code': 'E005'}  # Not currently used
 
     try:
-        data = simplejson.loads(request.raw_post_data)
-    except simplejson.JSONDecodeError:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
         data = ''
 
     if not isinstance(data, dict):
@@ -70,4 +70,4 @@ def api_rp(request):
     else:
         ret_data.update(result_code_invalid)
 
-    return HttpResponse(simplejson.dumps(ret_data), content_type='application/json')
+    return HttpResponse(json.dumps(ret_data), content_type='application/json')


### PR DESCRIPTION
## Summary

Quality: Deprecated simplejson Usage

## Problem

**Severity**: `Medium` | **File**: `tendenci/apps/api/views.py:L1`

The api/views.py file imports and uses simplejson, which is deprecated. The standard library json module should be used instead. Additionally, request.raw_post_data is deprecated in favor of request.body.

## Solution

Replace 'import simplejson' with 'import json' and replace request.raw_post_data with request.body.

## Changes

- `tendenci/apps/api/views.py` (modified)