### PR TITLE
Display user group description on Group View page

### DIFF
--- a/tendenci/themes/t7-base/templates/user_groups/detail.html
+++ b/tendenci/themes/t7-base/templates/user_groups/detail.html
@@ -31,6 +31,7 @@
     
     <div class="page-header">
       <h1>{{ group.name }}</h1>
+      <div>{{group.description}}</div>
     </div>
     
     {% if request.user.is_authenticated %}


### PR DESCRIPTION
Display the User Group Description so that, for example, users/members signing up for a mailing list group can see a description of what they are signing up for.

Submitted as a fix for issue #1439 